### PR TITLE
support for solr urls without a specified protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 Version numbers correspond to `bower.json` version
-
-# 1.0.0
-
-## Features
+# 0.1.10
 
 ## Bug Fixes
 
-## Breaking Changes
+- Support for Solr URL's without a protocol

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "splainer-search",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "splainer-search.js",
   "authors": [
     "Doug Turnbull <dturnbull@opensourceconnections.com>"

--- a/services/solrUrlSvc.js
+++ b/services/solrUrlSvc.js
@@ -74,11 +74,22 @@ angular.module('o19s.splainer-search')
       return null;
     };
 
+    /* private method fixURLProtocol
+     * add 'http://' to the begining of the url if no protocol was
+     * specified
+     * */
+    var protocolRegex = /^https{0,1}\:/;
+    function fixURLProtocol(url) {
+      if (!protocolRegex.test(url)) {
+        url = 'http://' + url;
+      }
+      return url;
+    }
     /* Parse a Sor URL of the form [http|https]://[host]/solr/[collectionName]/[requestHandler]?[args]
      * return null on failure to parse
      * */
     this.parseSolrUrl = function(solrReq) {
-
+      solrReq = fixURLProtocol(solrReq);
       var parseUrl = function(url) {
         // this is the crazy way you parse URLs in JS who am I to question the wisdom
         var a = document.createElement('a');

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1442,11 +1442,22 @@ angular.module('o19s.splainer-search')
       return null;
     };
 
+    /* private method fixURLProtocol
+     * add 'http://' to the begining of the url if no protocol was
+     * specified
+     * */
+    var protocolRegex = /^https{0,1}\:/;
+    function fixURLProtocol(url) {
+      if (!protocolRegex.test(url)) {
+        url = 'http://' + url;
+      }
+      return url;
+    }
     /* Parse a Sor URL of the form [http|https]://[host]/solr/[collectionName]/[requestHandler]?[args]
      * return null on failure to parse
      * */
     this.parseSolrUrl = function(solrReq) {
-
+      solrReq = fixURLProtocol(solrReq);
       var parseUrl = function(url) {
         // this is the crazy way you parse URLs in JS who am I to question the wisdom
         var a = document.createElement('a');

--- a/test/spec/solrUrlSvc.js
+++ b/test/spec/solrUrlSvc.js
@@ -57,6 +57,17 @@ describe('Service: solrUrlSvc', function () {
     expect(parsedSolrUrl.solrArgs.q).toContain('*:*');
   });
   
+  it('adds a missing protocol to solr url', function() {
+    var urlStr = 'localhost:8983/solr/collection1/select?q=*:*';
+
+    var parsedSolrUrl = solrUrlSvc.parseSolrUrl(urlStr);
+    expect(parsedSolrUrl.protocol).toEqual('http:');
+    expect(parsedSolrUrl.host).toEqual('localhost:8983');
+    expect(parsedSolrUrl.collectionName).toEqual('collection1');
+    expect(parsedSolrUrl.requestHandler).toEqual('select');
+    expect(parsedSolrUrl.solrArgs.q).toContain('*:*');
+  });
+
   it('doesnt warn on group arguments', function() {
     var urlStr = 'http://localhost:8983/solr/collection1/select?group=true&group.main=true&group.field=text&q=*:*';
     var parsedSolrUrl = solrUrlSvc.parseSolrUrl(urlStr);


### PR DESCRIPTION
@softwaredoug, this is the change from quepid pushed upstream.

Also I've iterated the bower version and started the changelog.
