### PR TITLE
Escape query

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,12 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.0"
+    "angular": "~1.4.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.21"
+    "angular-mocks": "~1.4.0"
+  },
+  "resolutions": {
+    "angular": "~1.4.0"
   }
 }

--- a/factories/resolverFactory.js
+++ b/factories/resolverFactory.js
@@ -57,9 +57,10 @@
       }
 
       self.config = {
-        sanitize:   false,
-        highlight:  false,
-        debug:      false,
+        sanitize:     false,
+        highlight:    false,
+        debug:        false,
+        escapeQuery:  false,
       };
 
       self.searcher = searchSvc.createSearcher(

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -6,9 +6,14 @@ angular.module('o19s.splainer-search')
     self.prepare  = prepare;
 
     var replaceQuery = function(args, queryText) {
-      var replaced = angular.toJson(args, true);
-      replaced = replaced.replace(/#\$query##/g, queryText);
-      replaced = angular.fromJson(replaced);
+      if (queryText) {
+        queryText = queryText.replace(/\\/g, "\\\\");;
+        queryText = queryText.replace(/"/g, '\\\"');
+      }
+
+      var replaced  = angular.toJson(args, true);
+      replaced      = replaced.replace(/#\$query##/g, queryText);
+      replaced      = angular.fromJson(replaced);
 
       return replaced;
     };

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -168,9 +168,14 @@ angular.module('o19s.splainer-search')
     self.prepare  = prepare;
 
     var replaceQuery = function(args, queryText) {
-      var replaced = angular.toJson(args, true);
-      replaced = replaced.replace(/#\$query##/g, queryText);
-      replaced = angular.fromJson(replaced);
+      if (queryText) {
+        queryText = queryText.replace(/\\/g, "\\\\");;
+        queryText = queryText.replace(/"/g, '\\\"');
+      }
+
+      var replaced  = angular.toJson(args, true);
+      replaced      = replaced.replace(/#\$query##/g, queryText);
+      replaced      = angular.fromJson(replaced);
 
       return replaced;
     };

--- a/test/mock/mockHelpers.js
+++ b/test/mock/mockHelpers.js
@@ -71,7 +71,7 @@ window.urlMissingParams = function(url, params) {
               found = true;
             }
           });
-        } 
+        }
       });
       return !found;
     }

--- a/values/defaultSolrConfig.js
+++ b/values/defaultSolrConfig.js
@@ -2,7 +2,8 @@
 
 angular.module('o19s.splainer-search')
   .value('defaultSolrConfig', {
-    sanitize:   true,
-    highlight:  true,
-    debug:      true
+    sanitize:     true,
+    highlight:    true,
+    debug:        true,
+    escapeQuery:  true
   });


### PR DESCRIPTION
# Changelog
- Escapes Solr queries to allow all kind of special characters:

<img width="174" alt="screen shot 2015-09-02 at 6 08 35 pm" src="https://cloud.githubusercontent.com/assets/29512/9646935/e2f7278c-519d-11e5-9796-14e54d61780d.png">
- Escapes ES queries to allow `"` and `\`:

<img width="203" alt="screen shot 2015-09-02 at 6 08 21 pm" src="https://cloud.githubusercontent.com/assets/29512/9646939/e99ad462-519d-11e5-9cd9-f22c13488d7a.png">
