### PR TITLE
Fixes missing docs when retrieving docs by id.

### DIFF
--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -77,7 +77,7 @@
       }
 
       var remaining       = self.numFound - pagerArgs.from;
-      pagerArgs.size      = Math.min(10, remaining);
+      pagerArgs.size      = Math.min(pagerArgs.size, remaining);
       nextArgs.pager      = pagerArgs;
 
       var options = {

--- a/factories/resolverFactory.js
+++ b/factories/resolverFactory.js
@@ -52,7 +52,8 @@
             'ids': {
               'values': ids
             }
-          }
+          },
+          size: ids.length
         };
       }
 

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1765,7 +1765,7 @@ angular.module('o19s.splainer-search')
       }
 
       var remaining       = self.numFound - pagerArgs.from;
-      pagerArgs.size      = Math.min(10, remaining);
+      pagerArgs.size      = Math.min(pagerArgs.size, remaining);
       nextArgs.pager      = pagerArgs;
 
       var options = {
@@ -1903,7 +1903,8 @@ angular.module('o19s.splainer-search')
             'ids': {
               'values': ids
             }
-          }
+          },
+          size: ids.length
         };
       }
 


### PR DESCRIPTION
The default size is set to 10, so when fetching docs
by id, it was only fetching the first 10 docs.
Fixed by passing `size: ids.length`
# Acceptance criteria
- When in quepid, and viewing an ES case with multiple queries and search results > 10, create a snapshot
- Enable diff with recently created snapshot
- Should not see "Missing doc: [doc id]"
