### PR TITLE
Extracts username and password from password from URL and passes it through the headers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.4.0"
+    "angular": "~1.4.0",
+    "urijs": "uri.js#~1.16.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.0"

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -123,7 +123,9 @@
       // Build URL with params if any
       // Eg. without params:  /_search
       // Eg. with params:     /_search?size=5&from=5
-      url = esUrlSvc.buildUrl(url, self.pagerArgs);
+      esUrlSvc.parseUrl(url);
+      esUrlSvc.setParams(self.pagerArgs);
+      url = esUrlSvc.buildUrl();
 
       activeQueries.count++;
       return $http.post(url, payload).success(function(data) {

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -127,8 +127,17 @@
       esUrlSvc.setParams(self.pagerArgs);
       url = esUrlSvc.buildUrl();
 
+      var requestConfig = {};
+
+      if ( angular.isDefined(esUrlSvc.username) && esUrlSvc.username !== '' &&
+        angular.isDefined(esUrlSvc.password) && esUrlSvc.password !== '') {
+        var authorization = 'Basic ' + esUrlSvc.username + ':' + esUrlSvc.password;
+        requestConfig.headers = { 'Authorization': authorization };
+      }
+
       activeQueries.count++;
-      return $http.post(url, payload).success(function(data) {
+      return $http.post(url, payload, requestConfig)
+      .success(function(data) {
         activeQueries.count--;
         self.numFound = data.hits.total;
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 	<script type="text/javascript" src="bower_components/angular-route/angular-route.min.js"></script>
 	<script type="text/javascript" src="bower_components/angular-sanitize/angular-sanitize.min.js"></script>
 	<script type="text/javascript" src="bower_components/angular-touch/angular-touch.min.js"></script>
+	<script type="text/javascript" src="bower_components/urijs/src/URI.min.js"></script>
 
 	<script type="text/javascript" src="services/normalDocsSvc.js"></script>
 	<script type="text/javascript" src="services/fieldSpecSvc.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,7 @@ module.exports = function(config) {
     files: [
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
+      'bower_components/urijs/src/URI.min.js',
       'module.js',
       'services/**/*.js',
       'factories/**/*.js',

--- a/karma.debug.conf.js
+++ b/karma.debug.conf.js
@@ -20,6 +20,7 @@ module.exports = function(config) {
     files: [
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
+      'bower_components/urijs/src/URI.min.js',
       'module.js',
       'services/**/*.js',
       'factories/**/*.js',

--- a/services/esUrlSvc.js
+++ b/services/esUrlSvc.js
@@ -4,13 +4,21 @@ angular.module('o19s.splainer-search')
   .service('esUrlSvc', function esUrlSvc() {
 
     var self      = this;
+
     self.protocol = null;
     self.host     = null;
     self.pathname = null;
+    self.username = null;
+    self.password = null;
+
+    self.parsed   = null;
+    self.params   = null;
 
     self.parseUrl     = parseUrl;
     self.buildDocUrl  = buildDocUrl;
     self.buildUrl     = buildUrl;
+    self.buildBaseUrl = buildBaseUrl;
+    self.setParams    = setParams;
 
     /**
      *
@@ -28,19 +36,22 @@ angular.module('o19s.splainer-search')
 
     /**
      *
-     * Parses an ES URL of the form [http|https]://[host][:port]/[collectionName]/_search
+     * Parses an ES URL of the form [http|https]://[username@password:][host][:port]/[collectionName]/_search
      * Splits up the different parts of the URL.
      *
      */
     function parseUrl (url) {
       url = fixURLProtocol(url);
-      var a = document.createElement('a');
-      a.href = url;
+      var a = new URI(url);
       url = a;
 
-      self.protocol = a.protocol;
-      self.host     = a.host;
-      self.pathname = a.pathname;
+      self.protocol = a.protocol();
+      self.host     = a.host();
+      self.pathname = a.pathname();
+      self.username = a.username();
+      self.password = a.password();
+
+      self.parsed   = true;
     };
 
     /**
@@ -54,7 +65,7 @@ angular.module('o19s.splainer-search')
       var type  = doc._type;
       var id    = doc._id;
 
-      var url = self.protocol + '//' + self.host;
+      var url = self.buildBaseUrl();
       url = url + '/' + index + '/' + type + '/' + id;
 
       return url;
@@ -65,15 +76,20 @@ angular.module('o19s.splainer-search')
      * Builds ES URL for a search query.
      * Adds any query params if present: /_search?from=10&size=10
      */
-    function buildUrl (url, params) {
+    function buildUrl () {
+      var self = this;
+
+      var url = self.buildBaseUrl();
+      url = url + self.pathname;
+
       // Return original URL if no params to append.
-      if (params === undefined ) {
+      if ( angular.isUndefined(self.params) ) {
         return url;
       }
 
       var paramsAsStrings = [];
 
-      angular.forEach(params, function(value, key) {
+      angular.forEach(self.params, function(value, key) {
         paramsAsStrings.push(key + '=' + value);
       });
 
@@ -91,5 +107,28 @@ angular.module('o19s.splainer-search')
       }
 
       return finalUrl;
+    }
+
+    function buildBaseUrl() {
+      if (!self.parsed) {
+        throw new UrlNotParseException();
+      }
+
+      var url = self.protocol + '://' + self.host;
+
+      return url
+    }
+
+    function setParams (params) {
+      var self    = this;
+      self.params = params;
+    }
+
+    function UrlNotParseException() {
+       var self = this;
+       self.message = "URL not parsed. Must call the parse() function first.";
+       self.toString = function() {
+          return self.message;
+       };
     }
   });

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1854,8 +1854,17 @@ angular.module('o19s.splainer-search')
       esUrlSvc.setParams(self.pagerArgs);
       url = esUrlSvc.buildUrl();
 
+      var requestConfig = {};
+
+      if ( angular.isDefined(esUrlSvc.username) && esUrlSvc.username !== '' &&
+        angular.isDefined(esUrlSvc.password) && esUrlSvc.password !== '') {
+        var authorization = 'Basic ' + esUrlSvc.username + ':' + esUrlSvc.password;
+        requestConfig.headers = { 'Authorization': authorization };
+      }
+
       activeQueries.count++;
-      return $http.post(url, payload).success(function(data) {
+      return $http.post(url, payload, requestConfig)
+      .success(function(data) {
         activeQueries.count--;
         self.numFound = data.hits.total;
 

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -199,13 +199,21 @@ angular.module('o19s.splainer-search')
   .service('esUrlSvc', function esUrlSvc() {
 
     var self      = this;
+
     self.protocol = null;
     self.host     = null;
     self.pathname = null;
+    self.username = null;
+    self.password = null;
+
+    self.parsed   = null;
+    self.params   = null;
 
     self.parseUrl     = parseUrl;
     self.buildDocUrl  = buildDocUrl;
     self.buildUrl     = buildUrl;
+    self.buildBaseUrl = buildBaseUrl;
+    self.setParams    = setParams;
 
     /**
      *
@@ -223,19 +231,22 @@ angular.module('o19s.splainer-search')
 
     /**
      *
-     * Parses an ES URL of the form [http|https]://[host][:port]/[collectionName]/_search
+     * Parses an ES URL of the form [http|https]://[username@password:][host][:port]/[collectionName]/_search
      * Splits up the different parts of the URL.
      *
      */
     function parseUrl (url) {
       url = fixURLProtocol(url);
-      var a = document.createElement('a');
-      a.href = url;
+      var a = new URI(url);
       url = a;
 
-      self.protocol = a.protocol;
-      self.host     = a.host;
-      self.pathname = a.pathname;
+      self.protocol = a.protocol();
+      self.host     = a.host();
+      self.pathname = a.pathname();
+      self.username = a.username();
+      self.password = a.password();
+
+      self.parsed   = true;
     };
 
     /**
@@ -249,7 +260,7 @@ angular.module('o19s.splainer-search')
       var type  = doc._type;
       var id    = doc._id;
 
-      var url = self.protocol + '//' + self.host;
+      var url = self.buildBaseUrl();
       url = url + '/' + index + '/' + type + '/' + id;
 
       return url;
@@ -260,15 +271,20 @@ angular.module('o19s.splainer-search')
      * Builds ES URL for a search query.
      * Adds any query params if present: /_search?from=10&size=10
      */
-    function buildUrl (url, params) {
+    function buildUrl () {
+      var self = this;
+
+      var url = self.buildBaseUrl();
+      url = url + self.pathname;
+
       // Return original URL if no params to append.
-      if (params === undefined ) {
+      if ( angular.isUndefined(self.params) ) {
         return url;
       }
 
       var paramsAsStrings = [];
 
-      angular.forEach(params, function(value, key) {
+      angular.forEach(self.params, function(value, key) {
         paramsAsStrings.push(key + '=' + value);
       });
 
@@ -286,6 +302,29 @@ angular.module('o19s.splainer-search')
       }
 
       return finalUrl;
+    }
+
+    function buildBaseUrl() {
+      if (!self.parsed) {
+        throw new UrlNotParseException();
+      }
+
+      var url = self.protocol + '://' + self.host;
+
+      return url
+    }
+
+    function setParams (params) {
+      var self    = this;
+      self.params = params;
+    }
+
+    function UrlNotParseException() {
+       var self = this;
+       self.message = "URL not parsed. Must call the parse() function first.";
+       self.toString = function() {
+          return self.message;
+       };
     }
   });
 
@@ -1811,7 +1850,9 @@ angular.module('o19s.splainer-search')
       // Build URL with params if any
       // Eg. without params:  /_search
       // Eg. with params:     /_search?size=5&from=5
-      url = esUrlSvc.buildUrl(url, self.pagerArgs);
+      esUrlSvc.parseUrl(url);
+      esUrlSvc.setParams(self.pagerArgs);
+      url = esUrlSvc.buildUrl();
 
       activeQueries.count++;
       return $http.post(url, payload).success(function(data) {

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -104,6 +104,39 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.verifyNoOutstandingExpectation();
       expect(called).toEqual(1);
     });
+
+    it('sets the proper headers for auth', function() {
+      searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList,
+        'http://username:password@localhost:9200/statedecoded/_search',
+        mockEsParams,
+        mockQueryText,
+        {},
+        'es'
+      );
+
+      $httpBackend.expectPOST(mockEsUrl, undefined, function(headers) {
+        return headers['Authorization'] == 'Basic username:password';
+      }).
+      respond(200, mockResults);
+
+      var called = 0;
+
+      searcher.search()
+      .then(function() {
+        var docs = searcher.docs;
+        expect(docs.length === 2);
+        expect(docs[0].field).toEqual(mockResults.hits.hits[0].fields.field[0]);
+        expect(docs[0].field1).toEqual(mockResults.hits.hits[0].fields.field1[0]);
+        expect(docs[1].field).toEqual(mockResults.hits.hits[1].fields.field[0]);
+        expect(docs[1].field1).toEqual(mockResults.hits.hits[1].fields.field1[0]);
+        called++;
+      });
+
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+      expect(called).toEqual(1);
+    });
   });
 
   describe('explain info', function() {

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -1,0 +1,44 @@
+'use strict';
+/*global describe,beforeEach,inject,it,expect*/
+describe('Service: esUrlSvc', function () {
+
+  beforeEach(module('o19s.splainer-search'));
+
+  var esUrlSvc;
+
+  beforeEach(inject(function (_esUrlSvc_) {
+    esUrlSvc = _esUrlSvc_;
+  }));
+
+  describe('parse URL', function() {
+    it('extracts the different parts of a URL', function() {
+      var url = 'http://localhost:9200/tmdb/_search';
+      esUrlSvc.parseUrl(url);
+
+      expect(esUrlSvc.protocol).toBe('http:');
+      expect(esUrlSvc.host).toBe('localhost:9200');
+      expect(esUrlSvc.pathname).toBe('/tmdb/_search');
+
+      var url = 'http://es.quepid.com/tmdb/_search';
+      esUrlSvc.parseUrl(url);
+
+      expect(esUrlSvc.protocol).toBe('http:');
+      expect(esUrlSvc.host).toBe('es.quepid.com');
+      expect(esUrlSvc.pathname).toBe('/tmdb/_search');
+
+      var url = 'https://es.quepid.com/tmdb/_search';
+      esUrlSvc.parseUrl(url);
+
+      expect(esUrlSvc.protocol).toBe('https:');
+      expect(esUrlSvc.host).toBe('es.quepid.com');
+      expect(esUrlSvc.pathname).toBe('/tmdb/_search');
+    });
+
+    it('adds http if the protocol is missing', function() {
+      var url = 'localhost:9200/tmdb/_search';
+      esUrlSvc.parseUrl(url);
+
+      expect(esUrlSvc.protocol).toBe('http:');
+    });
+  });
+});

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -15,21 +15,21 @@ describe('Service: esUrlSvc', function () {
       var url = 'http://localhost:9200/tmdb/_search';
       esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('http:');
+      expect(esUrlSvc.protocol).toBe('http');
       expect(esUrlSvc.host).toBe('localhost:9200');
       expect(esUrlSvc.pathname).toBe('/tmdb/_search');
 
       var url = 'http://es.quepid.com/tmdb/_search';
       esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('http:');
+      expect(esUrlSvc.protocol).toBe('http');
       expect(esUrlSvc.host).toBe('es.quepid.com');
       expect(esUrlSvc.pathname).toBe('/tmdb/_search');
 
       var url = 'https://es.quepid.com/tmdb/_search';
       esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('https:');
+      expect(esUrlSvc.protocol).toBe('https');
       expect(esUrlSvc.host).toBe('es.quepid.com');
       expect(esUrlSvc.pathname).toBe('/tmdb/_search');
     });
@@ -38,7 +38,27 @@ describe('Service: esUrlSvc', function () {
       var url = 'localhost:9200/tmdb/_search';
       esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('http:');
+      expect(esUrlSvc.protocol).toBe('http');
+    });
+
+    it('retrieves the username and password if available', function() {
+      var url = 'http://es.quepid.com/tmdb/_search';
+      esUrlSvc.parseUrl(url);
+
+      expect(esUrlSvc.username).toBe('');
+      expect(esUrlSvc.password).toBe('');
+
+      var url = 'http://username:password@es.quepid.com/tmdb/_search';
+      esUrlSvc.parseUrl(url);
+
+      expect(esUrlSvc.username).toBe('username');
+      expect(esUrlSvc.password).toBe('password');
+
+      var url = 'http://username:password@localhost:9200/tmdb/_search';
+      esUrlSvc.parseUrl(url);
+
+      expect(esUrlSvc.username).toBe('username');
+      expect(esUrlSvc.password).toBe('password');
     });
   });
 
@@ -62,30 +82,37 @@ describe('Service: esUrlSvc', function () {
     });
   });
 
-  describe('build doc URL', function() {
+  describe('build URL', function() {
     var url = 'http://localhost:9200/tmdb/_search';
 
+    beforeEach( function () {
+      esUrlSvc.parseUrl(url);
+    });
+
     it('returns the original URL if no params are passed', function() {
-      var returnedUrl = esUrlSvc.buildUrl(url);
+      var returnedUrl = esUrlSvc.buildUrl();
 
       expect(returnedUrl).toBe(url);
     });
 
     it('returns the original URL if params passed is empty', function() {
       var params = { };
-      var returnedUrl = esUrlSvc.buildUrl(url, params);
+      esUrlSvc.setParams(params);
+      var returnedUrl = esUrlSvc.buildUrl();
 
       expect(returnedUrl).toBe(url);
     });
 
     it('appends params to the original URL', function() {
       var params = { foo: "bar" };
-      var returnedUrl = esUrlSvc.buildUrl(url, params);
+      esUrlSvc.setParams(params);
+      var returnedUrl = esUrlSvc.buildUrl();
 
       expect(returnedUrl).toBe(url + '?foo=bar');
 
       var params = { foo: "bar", bar: "foo" };
-      var returnedUrl = esUrlSvc.buildUrl(url, params);
+      esUrlSvc.setParams(params);
+      var returnedUrl = esUrlSvc.buildUrl();
 
       expect(returnedUrl).toBe(url + '?foo=bar&bar=foo');
     });

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -61,4 +61,33 @@ describe('Service: esUrlSvc', function () {
       expect(docUrl).toBe('http://localhost:9200/tmdb/movies/1');
     });
   });
+
+  describe('build doc URL', function() {
+    var url = 'http://localhost:9200/tmdb/_search';
+
+    it('returns the original URL if no params are passed', function() {
+      var returnedUrl = esUrlSvc.buildUrl(url);
+
+      expect(returnedUrl).toBe(url);
+    });
+
+    it('returns the original URL if params passed is empty', function() {
+      var params = { };
+      var returnedUrl = esUrlSvc.buildUrl(url, params);
+
+      expect(returnedUrl).toBe(url);
+    });
+
+    it('appends params to the original URL', function() {
+      var params = { foo: "bar" };
+      var returnedUrl = esUrlSvc.buildUrl(url, params);
+
+      expect(returnedUrl).toBe(url + '?foo=bar');
+
+      var params = { foo: "bar", bar: "foo" };
+      var returnedUrl = esUrlSvc.buildUrl(url, params);
+
+      expect(returnedUrl).toBe(url + '?foo=bar&bar=foo');
+    });
+  });
 });

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -41,4 +41,24 @@ describe('Service: esUrlSvc', function () {
       expect(esUrlSvc.protocol).toBe('http:');
     });
   });
+
+  describe('build doc URL', function() {
+    var url = 'http://localhost:9200/tmdb/_search';
+
+    var doc = {
+      _index: 'tmdb',
+      _type:  'movies',
+      _id:    '1'
+    }
+
+    beforeEach( function () {
+      esUrlSvc.parseUrl(url);
+    });
+
+    it('builds a proper doc URL from the doc info', function() {
+      var docUrl = esUrlSvc.buildDocUrl(doc);
+
+      expect(docUrl).toBe('http://localhost:9200/tmdb/movies/1');
+    });
+  });
 });


### PR DESCRIPTION
# Changelog
- Switched from using the `a` tag to parse a url to using the URI.js module for ES
- Extracts username and password from URL if available and passes them through the headers for ES
# Acceptance criteria
- When using a URL of the form `http://username:passwoard@domain.com`, the call goes through and works
