### PR TITLE
Removes copying behavior in normalDocsSvc

### DIFF
--- a/factories/docFactory.js
+++ b/factories/docFactory.js
@@ -7,30 +7,34 @@
     .factory('DocFactory', [DocFactory]);
 
   function DocFactory() {
-    var Doc = function(doc, options) {
+    var Doc = function(doc, opts) {
       var self        = this;
 
       angular.copy(doc, self);
 
-      self.options    = options;
       self.doc        = doc;
 
       self.groupedBy  = groupedBy;
       self.group      = group;
+      self.options      = options;
 
       function groupedBy () {
-        if (options.groupedBy === undefined) {
+        if (opts.groupedBy === undefined) {
           return null;
         } else {
-          return options.groupedBy;
+          return opts.groupedBy;
         }
       }
 
+      function options() {
+        return opts;
+      }
+
       function group () {
-        if (options.group === undefined) {
+        if (opts.group === undefined) {
           return null;
         } else {
-          return options.group;
+          return opts.group;
         }
       }
     };

--- a/factories/esDocFactory.js
+++ b/factories/esDocFactory.js
@@ -42,7 +42,7 @@
       /*jslint validthis:true*/
       var self  = this;
       var doc   = self.doc;
-      var esurl = self.options.url;
+      var esurl = self.options().url;
 
       esUrlSvc.parseUrl(esurl);
       return esUrlSvc.buildDocUrl(doc);
@@ -51,7 +51,7 @@
     function explain () {
       /*jslint validthis:true*/
       var self = this;
-      return self.options.explDict;
+      return self.options().explDict;
     }
 
     function snippet (docId, fieldName) {

--- a/factories/solrDocFactory.js
+++ b/factories/solrDocFactory.js
@@ -66,15 +66,15 @@
     function url (idField, docId) {
       /*jslint validthis:true*/
       var self = this;
-      return buildTokensUrl(self.options.fieldList, self.options.url, idField, docId);
+      return buildTokensUrl(self.options().fieldList, self.options().url, idField, docId);
     }
 
     function explain (docId) {
       /*jslint validthis:true*/
       var self = this;
 
-      if (self.options.explDict.hasOwnProperty(docId)) {
-        return self.options.explDict[docId];
+      if (self.options().explDict.hasOwnProperty(docId)) {
+        return self.options().explDict[docId];
       } else {
         return null;
       }
@@ -84,8 +84,8 @@
       /*jslint validthis:true*/
       var self = this;
 
-      if (self.options.hlDict.hasOwnProperty(docId)) {
-        var docHls = self.options.hlDict[docId];
+      if (self.options().hlDict.hasOwnProperty(docId)) {
+        var docHls = self.options().hlDict[docId];
         if (docHls.hasOwnProperty(fieldName)) {
           return docHls[fieldName];
         }
@@ -106,9 +106,9 @@
 
       if (fieldValue) {
         var esc       = escapeHtml(fieldValue);
-        var preRegex  = new RegExp(self.options.highlightingPre, 'g');
+        var preRegex  = new RegExp(self.options().highlightingPre, 'g');
         var hlPre     = esc.replace(preRegex, preText);
-        var postRegex = new RegExp(self.options.highlightingPost, 'g');
+        var postRegex = new RegExp(self.options().highlightingPost, 'g');
 
         return hlPre.replace(postRegex, postText);
       } else {

--- a/services/normalDocSvc.js
+++ b/services/normalDocSvc.js
@@ -177,13 +177,11 @@ angular.module('o19s.splainer-search')
     // Decorate doc with an explain/field values/etc other
     // than what came back from the search engine
     this.explainDoc = function(doc, explainJson) {
-      var decorated = angular.copy(doc);
-      return explainable(decorated, explainJson);
+      return explainable(doc, explainJson);
     };
 
     this.snippetDoc = function(doc) {
-      var decorated = angular.copy(doc);
-      return snippitable(decorated);
+      return snippitable(doc);
     };
 
     // A stub, used to display a result that we expected

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1584,30 +1584,34 @@ angular.module('o19s.splainer-search')
     .factory('DocFactory', [DocFactory]);
 
   function DocFactory() {
-    var Doc = function(doc, options) {
+    var Doc = function(doc, opts) {
       var self        = this;
 
       angular.copy(doc, self);
 
-      self.options    = options;
       self.doc        = doc;
 
       self.groupedBy  = groupedBy;
       self.group      = group;
+      self.options      = options;
 
       function groupedBy () {
-        if (options.groupedBy === undefined) {
+        if (opts.groupedBy === undefined) {
           return null;
         } else {
-          return options.groupedBy;
+          return opts.groupedBy;
         }
       }
 
+      function options() {
+        return opts;
+      }
+
       function group () {
-        if (options.group === undefined) {
+        if (opts.group === undefined) {
           return null;
         } else {
-          return options.group;
+          return opts.group;
         }
       }
     };
@@ -1661,7 +1665,7 @@ angular.module('o19s.splainer-search')
       /*jslint validthis:true*/
       var self  = this;
       var doc   = self.doc;
-      var esurl = self.options.url;
+      var esurl = self.options().url;
 
       esUrlSvc.parseUrl(esurl);
       return esUrlSvc.buildDocUrl(doc);
@@ -1670,7 +1674,7 @@ angular.module('o19s.splainer-search')
     function explain () {
       /*jslint validthis:true*/
       var self = this;
-      return self.options.explDict;
+      return self.options().explDict;
     }
 
     function snippet (docId, fieldName) {
@@ -2139,15 +2143,15 @@ angular.module('o19s.splainer-search')
     function url (idField, docId) {
       /*jslint validthis:true*/
       var self = this;
-      return buildTokensUrl(self.options.fieldList, self.options.url, idField, docId);
+      return buildTokensUrl(self.options().fieldList, self.options().url, idField, docId);
     }
 
     function explain (docId) {
       /*jslint validthis:true*/
       var self = this;
 
-      if (self.options.explDict.hasOwnProperty(docId)) {
-        return self.options.explDict[docId];
+      if (self.options().explDict.hasOwnProperty(docId)) {
+        return self.options().explDict[docId];
       } else {
         return null;
       }
@@ -2157,8 +2161,8 @@ angular.module('o19s.splainer-search')
       /*jslint validthis:true*/
       var self = this;
 
-      if (self.options.hlDict.hasOwnProperty(docId)) {
-        var docHls = self.options.hlDict[docId];
+      if (self.options().hlDict.hasOwnProperty(docId)) {
+        var docHls = self.options().hlDict[docId];
         if (docHls.hasOwnProperty(fieldName)) {
           return docHls[fieldName];
         }
@@ -2179,9 +2183,9 @@ angular.module('o19s.splainer-search')
 
       if (fieldValue) {
         var esc       = escapeHtml(fieldValue);
-        var preRegex  = new RegExp(self.options.highlightingPre, 'g');
+        var preRegex  = new RegExp(self.options().highlightingPre, 'g');
         var hlPre     = esc.replace(preRegex, preText);
-        var postRegex = new RegExp(self.options.highlightingPost, 'g');
+        var postRegex = new RegExp(self.options().highlightingPost, 'g');
 
         return hlPre.replace(postRegex, postText);
       } else {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -749,13 +749,11 @@ angular.module('o19s.splainer-search')
     // Decorate doc with an explain/field values/etc other
     // than what came back from the search engine
     this.explainDoc = function(doc, explainJson) {
-      var decorated = angular.copy(doc);
-      return explainable(decorated, explainJson);
+      return explainable(doc, explainJson);
     };
 
     this.snippetDoc = function(doc) {
-      var decorated = angular.copy(doc);
-      return snippitable(decorated);
+      return snippitable(doc);
     };
 
     // A stub, used to display a result that we expected

--- a/test/spec/normalDocSvc.js
+++ b/test/spec/normalDocSvc.js
@@ -6,7 +6,7 @@ describe('Service: normalDocsSvc', function () {
 
   // load the service's module
   beforeEach(module('o19s.splainer-search'));
- 
+
   /*jshint camelcase: false */
   var normalDocsSvc = null;
   var vectorSvc = null;
@@ -91,7 +91,7 @@ describe('Service: normalDocsSvc', function () {
       expect(normalDoc.subSnippets().another_field).toContain('&gt;');
       expect(normalDoc.subSnippets().another_field).toContain('&lt;');
   });
-  
+
   describe('highlight tests', function() {
     var availableHighlight = null;
     var solrDoc = null;
@@ -119,7 +119,7 @@ describe('Service: normalDocsSvc', function () {
       var snips = normalDoc.subSnippets('<b>', '</b>');
       expect(snips.another_field).toEqual('<b>' + availableHighlight + '</b>');
     });
-    
+
     it('uses highlights for sub fileds', function() {
       availableHighlight = 'something';
       var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: ['another_field']};
@@ -127,7 +127,7 @@ describe('Service: normalDocsSvc', function () {
       expect(normalDoc.subs.another_field).toEqual(solrDoc.another_field);
       expect(normalDoc.title).toEqual(solrDoc.title_field);
     });
-    
+
     it('uses orig value on no hl', function() {
       availableHighlight = null;
       var anotherFieldValue =solrDoc.another_field;
@@ -206,17 +206,9 @@ describe('Service: normalDocsSvc', function () {
       expect(hmOutOf.length).toBe(1);
       expect(hmOutOf[0].description).toContain('order');
       expect(hmOutOf[0].percentage).toBe(50.0);
-      
+
       var expl = decoratedDoc.explain();
       expect(expl.explanation()).toContain('order');
-    });
-    
-    it('decorates and leaves alone original', function() {
-      var fieldSpec = {id: 'custom_id_field', title: 'title_field'};
-      var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDocNoExpl);
-      var explBefore = normalDoc.explain();
-      normalDocsSvc.explainDoc(normalDoc, basicExplain2);
-      expect(explBefore).toEqual(normalDoc.explain());
     });
 
     it('uses alt explain if available', function() {
@@ -226,7 +218,7 @@ describe('Service: normalDocsSvc', function () {
       expect(hmOutOf.length).toBe(1);
       expect(hmOutOf[0].description).toContain('order');
       expect(hmOutOf[0].percentage).toBe(50.0);
-      
+
       var expl = normalDoc.explain();
       expect(expl.explanation()).toContain('order');
     });
@@ -252,16 +244,16 @@ describe('Service: normalDocsSvc', function () {
           return sumExplain;
         }
         return null;
-      }; 
+      };
       var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
       expect(idVals.length).toBe(2); // 2 lookups
       expect(idVals[0]).toEqual(solrDoc.source().custom_id_field);
       expect(idVals[1]).toEqual(solrDoc.source().id);
       expect(normalDoc.score()).toEqual(1.0);
     });
-    
+
   });
-  
+
   describe('uses source(), not fields on doc', function() {
     var solrDoc = null;
     var availableHighlights = {};
@@ -293,7 +285,7 @@ describe('Service: normalDocsSvc', function () {
                    return null;
                  } };
     });
-      
+
     it('reads fields', function() {
       var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: '*'};
       var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
@@ -337,7 +329,7 @@ describe('Service: normalDocsSvc', function () {
       expect(normalDoc.subs.sub1).toEqual('sub1_val');
       expect(normalDoc.subs.sub2).toEqual('sub2_val');
     });
-    
+
     it('captures sub values w/ highlight', function() {
       var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: '*'};
       availableHighlights.sub1 = 'sub1_hl';

--- a/test/spec/normalDocSvc.js
+++ b/test/spec/normalDocSvc.js
@@ -211,6 +211,14 @@ describe('Service: normalDocsSvc', function () {
       expect(expl.explanation()).toContain('order');
     });
 
+    it('decorated doc same as original', function() {
+      // we need these to be the same to preserve memory
+      var fieldSpec = {id: 'custom_id_field', title: 'title_field'};
+      var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDocNoExpl);
+      var decoratedDoc = normalDocsSvc.explainDoc(normalDoc, basicExplain2);
+      expect(decoratedDoc).toBe(normalDoc);
+    });
+
     it('uses alt explain if available', function() {
       var fieldSpec = {id: 'custom_id_field', title: 'title_field'};
       var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDocNoExpl, basicExplain2);


### PR DESCRIPTION
As we've created the solr/ES doc factories, we've made more items properties of the doc or the doc's options. For example, the explDict is a handle to the dictionary of explain information for the query.

Unfortunately, we also deep copy this doc in normalDocSvc for a Quepid-specific reason (see related Quepid PR). This deep copy creates a ton of extra copies of items such as the rather large explain dictionary, highlight snippets etc. Instead of these being handles back to a single dictionary they use to lookup information, every doc instead have its own copy of all this info. The memory usage bloats, and prevents Quepid from showing larger amounts of queries.
