### PR TITLE
Elasticsearch bulk search

### DIFF
--- a/factories/bulkTransportFactory.js
+++ b/factories/bulkTransportFactory.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/*jslint latedef:false*/
+
+(function() {
+  angular.module('o19s.splainer-search')
+    .factory('HttpPostTransportFactory', [
+      'TransportFactory',
+      '$http',
+      HttpPostTransportFactory
+    ]);
+
+
+  function HttpPostTransportFactory(TransportFactory, $http, $q, $timeout) {
+    var BulkTransporter = function(url, headers) {
+
+      var requestConfig = {headers: headers};
+      var self = this;
+      self.enqueue = enqueue;
+      var queue = [];
+      var pendingHttp = null;
+
+      function dequeue(bulkHttpResp) {
+        if (bulkHttpResp.hasOwnProperty('responses'))  {
+          var queueIdx = 0;
+          var respLen = bulkHttpResp.responses.length;
+          angular.forEach(bulkHttpResp.responses, function(resp) {
+            if (resp.hasOwnProperty('error')) {
+              currRequest.defered.reject(resp);
+              // individual query failure
+            } else {
+              var currRequest = queue[queueIdx];
+              currRequest.defered.resolve(resp);
+            }
+
+            queueIdx++;
+          });
+          queue.slice(respLen);
+        } else {
+          allFailed(bulkHttpResp);
+        }
+      }
+
+      function allFailed(bulkHttpResp) {
+        var numInFlight = 0;
+        angular.forEach(queue, function(pendingQuery) {
+          if (pendingQuery.inFlight) {
+            pendingQuery.defered.reject(bulkHttpResp);
+            // fail them
+            numInFlight++;
+          }
+        });
+        queue.slice(numInFlight);
+      }
+
+      function tryHttp() {
+        if (!pendingHttp) {
+          // Implementation of Elasticsearch's _msearch ("Multi Search") API
+          var sharedHeader = {}; // means use inde
+          var queryLines = [];
+          angular.forEach(queue, function(pendingQuery) {
+            queryLines.push(sharedHeader);
+            pendingQuery.inFlight = true;
+            queryLines.push(pendingQuery.payload);
+          });
+          var data = '\n'.join(queryLines);
+          pendingHttp = $http.post(url, data, requestConfig);
+          pendingHttp.then(dequeue, allFailed);
+        }
+      }
+
+      function enqueue(payload) {
+        var defered = $q.defer();
+
+        var pendingQuery = {
+          defered: defered,
+          inFlight: false,
+          payload: payload,
+        };
+        queue.push(pendingQuery);
+        return defered.promise;
+      }
+
+      function timerTick() {
+        tryHttp();
+        $timeout(100, timerTick);
+      }
+
+      $timeout(100, timerTick);
+
+
+    };
+
+    var Transport = function(options) {
+      TransportFactory.call(this, options);
+      this.bulkTransporter = null;
+    };
+
+    Transport.prototype = Object.create(TransportFactory.prototype);
+    Transport.prototype.constructor = Transport;
+
+    Transport.prototype.query = query;
+
+    function query(url, payload, headers) {
+      var self = this;
+      if (!self.bulkTransporter) {
+        self.bulkTransporter = new BulkTransporter(url, headers);
+      }
+      return self.bulkTransporter.enqueue(payload);
+
+    }
+
+    return Transport;
+  }
+})();

--- a/factories/bulkTransportFactory.js
+++ b/factories/bulkTransportFactory.js
@@ -19,6 +19,7 @@
       var requestConfig = {headers: headers};
       var self = this;
       self.enqueue = enqueue;
+      self.url = getUrl;
       var queue = [];
       var pendingHttp = null;
 
@@ -72,7 +73,7 @@
             queryLines.push(JSON.stringify(pendingQuery.payload));
           });
           var data = queryLines.join('\n');
-          pendingHttp = $http.post(url, data, requestConfig);
+          pendingHttp = $http.post(url, data + '\n', requestConfig);
           pendingHttp.then(dequeue, allFailed);
         }
       }
@@ -94,6 +95,10 @@
         $timeout(timerTick, 100);
       }
 
+      function getUrl() {
+        return url;
+      }
+
       $timeout(timerTick, 100);
 
 
@@ -112,6 +117,9 @@
     function query(url, payload, headers) {
       var self = this;
       if (!self.bulkTransporter) {
+        self.bulkTransporter = new BulkTransporter(url, headers);
+      }
+      else if (self.bulkTransporter.url() !== url) {
         self.bulkTransporter = new BulkTransporter(url, headers);
       }
       return self.bulkTransporter.enqueue(payload);

--- a/factories/bulkTransportFactory.js
+++ b/factories/bulkTransportFactory.js
@@ -62,7 +62,7 @@
       }
 
       function tryHttp() {
-        if (!pendingHttp) {
+        if (!pendingHttp && queue.length > 0) {
           // Implementation of Elasticsearch's _msearch ("Multi Search") API
           var sharedHeader = JSON.stringify({}); // means use inde
           var queryLines = [];

--- a/factories/bulkTransportFactory.js
+++ b/factories/bulkTransportFactory.js
@@ -39,7 +39,8 @@
               currRequest.defered.reject(resp);
               // individual query failure
             } else {
-              currRequest.defered.resolve(resp);
+              // make the response look like standard response
+              currRequest.defered.resolve({'data': resp});
             }
 
             queueIdx++;

--- a/factories/esDocFactory.js
+++ b/factories/esDocFactory.js
@@ -44,8 +44,8 @@
       var doc   = self.doc;
       var esurl = self.options().url;
 
-      esUrlSvc.parseUrl(esurl);
-      return esUrlSvc.buildDocUrl(doc);
+      var uri = esUrlSvc.parseUrl(esurl);
+      return esUrlSvc.buildDocUrl(uri, doc);
     }
 
     function explain () {

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -6,6 +6,7 @@
   angular.module('o19s.splainer-search')
     .factory('EsSearcherFactory', [
       '$http',
+      '$q',
       'EsDocFactory',
       'activeQueries',
       'esSearcherPreprocessorSvc',
@@ -15,7 +16,7 @@
       EsSearcherFactory
     ]);
 
-  function EsSearcherFactory($http, EsDocFactory, activeQueries, esSearcherPreprocessorSvc, esUrlSvc, SearcherFactory, transportSvc) {
+  function EsSearcherFactory($http, $q, EsDocFactory, activeQueries, esSearcherPreprocessorSvc, esUrlSvc, SearcherFactory, transportSvc) {
 
     var Searcher = function(options) {
       SearcherFactory.call(this, options, esSearcherPreprocessorSvc);
@@ -169,9 +170,10 @@
           var doc = parseDoc(hit);
           thisSearcher.docs.push(doc);
         });
-      }, function error() {
+      }, function error(msg) {
         activeQueries.count--;
         thisSearcher.inError = true;
+        return $q.reject(msg);
       });
     }
 

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -98,7 +98,11 @@
       /*jslint validthis:true*/
       var self      = this;
       var url       = self.url;
-      var payload   = self.queryDsl;
+      var queryDslWithPagerArgs = angular.copy(self.queryDsl);
+      if (self.pagerArgs) {
+        queryDslWithPagerArgs.from = self.pagerArgs.from;
+        queryDslWithPagerArgs.size = self.pagerArgs.size;
+      }
       self.inError  = false;
 
       var thisSearcher  = self;
@@ -124,7 +128,7 @@
       // Eg. without params:  /_search
       // Eg. with params:     /_search?size=5&from=5
       var uri = esUrlSvc.parseUrl(url);
-      esUrlSvc.setParams(uri, self.pagerArgs);
+      //esUrlSvc.setParams(uri, self.pagerArgs);
       url = esUrlSvc.buildUrl(uri);
 
       var requestConfig = {};
@@ -136,7 +140,7 @@
       }
 
       activeQueries.count++;
-      return $http.post(url, payload, requestConfig)
+      return $http.post(url, queryDslWithPagerArgs, requestConfig)
       .success(function(data) {
         activeQueries.count--;
         self.numFound = data.hits.total;

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -144,7 +144,8 @@
 
       activeQueries.count++;
       return self.transport.query(url, queryDslWithPagerArgs, headers)
-      .success(function(data) {
+      .then(function success(httpConfig) {
+        var data = httpConfig.data;
         activeQueries.count--;
         self.numFound = data.hits.total;
 
@@ -168,7 +169,7 @@
           var doc = parseDoc(hit);
           thisSearcher.docs.push(doc);
         });
-      }).error(function() {
+      }, function error() {
         activeQueries.count--;
         thisSearcher.inError = true;
       });

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -99,8 +99,10 @@
     function search () {
       /*jslint validthis:true*/
       var self      = this;
-      self.transport = transportSvc.getTransport();
       var url       = self.url;
+      var uri = esUrlSvc.parseUrl(url);
+      url = esUrlSvc.buildUrl(uri);
+      var transport = transportSvc.getTransport({searchApi: uri.searchApi});
       var queryDslWithPagerArgs = angular.copy(self.queryDsl);
       if (self.pagerArgs) {
         queryDslWithPagerArgs.from = self.pagerArgs.from;
@@ -130,9 +132,7 @@
       // Build URL with params if any
       // Eg. without params:  /_search
       // Eg. with params:     /_search?size=5&from=5
-      var uri = esUrlSvc.parseUrl(url);
       //esUrlSvc.setParams(uri, self.pagerArgs);
-      url = esUrlSvc.buildUrl(uri);
 
       var headers = {};
 
@@ -143,7 +143,7 @@
       }
 
       activeQueries.count++;
-      return self.transport.query(url, queryDslWithPagerArgs, headers)
+      return transport.query(url, queryDslWithPagerArgs, headers)
       .then(function success(httpConfig) {
         var data = httpConfig.data;
         activeQueries.count--;

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -123,15 +123,15 @@
       // Build URL with params if any
       // Eg. without params:  /_search
       // Eg. with params:     /_search?size=5&from=5
-      esUrlSvc.parseUrl(url);
-      esUrlSvc.setParams(self.pagerArgs);
-      url = esUrlSvc.buildUrl();
+      var uri = esUrlSvc.parseUrl(url);
+      esUrlSvc.setParams(uri, self.pagerArgs);
+      url = esUrlSvc.buildUrl(uri);
 
       var requestConfig = {};
 
-      if ( angular.isDefined(esUrlSvc.username) && esUrlSvc.username !== '' &&
-        angular.isDefined(esUrlSvc.password) && esUrlSvc.password !== '') {
-        var authorization = 'Basic ' + btoa(esUrlSvc.username + ':' + esUrlSvc.password);
+      if ( angular.isDefined(uri.username) && uri.username !== '' &&
+        angular.isDefined(uri.password) && uri.password !== '') {
+        var authorization = 'Basic ' + btoa(uri.username + ':' + uri.password);
         requestConfig.headers = { 'Authorization': authorization };
       }
 

--- a/factories/httpPostTransportFactory.js
+++ b/factories/httpPostTransportFactory.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/*jslint latedef:false*/
+
+(function() {
+  angular.module('o19s.splainer-search')
+    .factory('HttpPostTransportFactory', [
+      'TransportFactory',
+      '$http',
+      HttpPostTransportFactory
+    ]);
+
+  function HttpPostTransportFactory(TransportFactory, $http) {
+    var Transport = function(options) {
+      TransportFactory.call(this, options);
+    };
+
+    Transport.prototype = Object.create(TransportFactory.prototype);
+    Transport.prototype.constructor = Transport;
+
+    Transport.prototype.query = query;
+
+    function query(url, payload, headers) {
+      var requestConfig = {headers: headers};
+      return $http.post(url, payload, requestConfig);
+    }
+
+    return Transport;
+  }
+})();

--- a/factories/transportFactory.js
+++ b/factories/transportFactory.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/*jslint latedef:false*/
+
+(function() {
+  angular.module('o19s.splainer-search')
+    .factory('TransportFactory', [TransportFactory]);
+
+  function TransportFactory() {
+    var Transporter = function(opts) {
+      var self                = this;
+
+      self.options = options;
+
+      function options() {
+        return opts;
+      }
+
+    };
+
+    // Return factory object
+    return Transporter;
+  }
+})();

--- a/services/esUrlSvc.js
+++ b/services/esUrlSvc.js
@@ -42,8 +42,17 @@ angular.module('o19s.splainer-search')
         host: a.host(),
         pathname: a.pathname(),
         username: a.username(),
-        password: a.password()
+        password: a.password(),
+        searchApi: 'post'
       };
+
+      if (esUri.pathname.endsWith('/')) {
+        esUri.pathname = esUri.pathname.substring(0, esUri.pathname.length - 1);
+      }
+
+      if (esUri.pathname.endsWith('_msearch')) {
+        esUri.searchApi = 'bulk';
+      }
 
       return esUri;
     }

--- a/services/esUrlSvc.js
+++ b/services/esUrlSvc.js
@@ -1,18 +1,10 @@
 'use strict';
 
+/*global URI*/
 angular.module('o19s.splainer-search')
   .service('esUrlSvc', function esUrlSvc() {
 
     var self      = this;
-
-    self.protocol = null;
-    self.host     = null;
-    self.pathname = null;
-    self.username = null;
-    self.password = null;
-
-    self.parsed   = null;
-    self.params   = null;
 
     self.parseUrl     = parseUrl;
     self.buildDocUrl  = buildDocUrl;
@@ -45,13 +37,15 @@ angular.module('o19s.splainer-search')
       var a = new URI(url);
       url = a;
 
-      self.protocol = a.protocol();
-      self.host     = a.host();
-      self.pathname = a.pathname();
-      self.username = a.username();
-      self.password = a.password();
+      var esUri = {
+        protocol: a.protocol(),
+        host: a.host(),
+        pathname: a.pathname(),
+        username: a.username(),
+        password: a.password()
+      };
 
-      self.parsed   = true;
+      return esUri;
     }
 
     /**
@@ -60,12 +54,12 @@ angular.module('o19s.splainer-search')
      * for an ES document.
      *
      */
-    function buildDocUrl (doc) {
+    function buildDocUrl (uri, doc) {
       var index = doc._index;
       var type  = doc._type;
       var id    = doc._id;
 
-      var url = self.buildBaseUrl();
+      var url = self.buildBaseUrl(uri);
       url = url + '/' + index + '/' + type + '/' + id;
 
       return url;
@@ -76,20 +70,20 @@ angular.module('o19s.splainer-search')
      * Builds ES URL for a search query.
      * Adds any query params if present: /_search?from=10&size=10
      */
-    function buildUrl () {
+    function buildUrl (uri) {
       var self = this;
 
-      var url = self.buildBaseUrl();
-      url = url + self.pathname;
+      var url = self.buildBaseUrl(uri);
+      url = url + uri.pathname;
 
       // Return original URL if no params to append.
-      if ( angular.isUndefined(self.params) ) {
+      if ( angular.isUndefined(uri.params) ) {
         return url;
       }
 
       var paramsAsStrings = [];
 
-      angular.forEach(self.params, function(value, key) {
+      angular.forEach(uri.params, function(value, key) {
         paramsAsStrings.push(key + '=' + value);
       });
 
@@ -109,26 +103,13 @@ angular.module('o19s.splainer-search')
       return finalUrl;
     }
 
-    function buildBaseUrl() {
-      if (!self.parsed) {
-        throw new UrlNotParseException();
-      }
-
-      var url = self.protocol + '://' + self.host;
+    function buildBaseUrl(uri) {
+      var url = uri.protocol + '://' + uri.host;
 
       return url;
     }
 
-    function setParams (params) {
-      var self    = this;
-      self.params = params;
-    }
-
-    function UrlNotParseException() {
-       var self = this;
-       self.message = 'URL not parsed. Must call the parse() function first.';
-       self.toString = function() {
-          return self.message;
-       };
+    function setParams (uri, params) {
+      uri.params = params;
     }
   });

--- a/services/transportSvc.js
+++ b/services/transportSvc.js
@@ -1,0 +1,11 @@
+'use strict';
+
+angular.module('o19s.splainer-search')
+  .service('transportSvc', function transportSvc(HttpPostTransportFactory) {
+    var self = this;
+    self.getTransport = getTransport;
+
+    function getTransport(options) {
+      return new HttpPostTransportFactory(options);
+    }
+  });

--- a/services/transportSvc.js
+++ b/services/transportSvc.js
@@ -1,11 +1,14 @@
 'use strict';
 
 angular.module('o19s.splainer-search')
-  .service('transportSvc', function transportSvc(HttpPostTransportFactory) {
+  .service('transportSvc', function transportSvc(HttpPostTransportFactory, BulkTransportFactory) {
     var self = this;
     self.getTransport = getTransport;
 
     function getTransport(options) {
+      if (options.searchApi === 'bulk') {
+        return new BulkTransportFactory(options);
+      }
       return new HttpPostTransportFactory(options);
     }
   });

--- a/services/transportSvc.js
+++ b/services/transportSvc.js
@@ -4,11 +4,13 @@ angular.module('o19s.splainer-search')
   .service('transportSvc', function transportSvc(HttpPostTransportFactory, BulkTransportFactory) {
     var self = this;
     self.getTransport = getTransport;
+    var bulkTransport = new BulkTransportFactory({});
+    var httpPostTransport = new HttpPostTransportFactory({});
 
     function getTransport(options) {
       if (options.searchApi === 'bulk') {
-        return new BulkTransportFactory(options);
+        return bulkTransport;
       }
-      return new HttpPostTransportFactory(options);
+      return httpPostTransport;
     }
   });

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1486,12 +1486,14 @@ angular.module('o19s.splainer-search')
   .service('transportSvc', function transportSvc(HttpPostTransportFactory, BulkTransportFactory) {
     var self = this;
     self.getTransport = getTransport;
+    var bulkTransport = new BulkTransportFactory({});
+    var httpPostTransport = new HttpPostTransportFactory({});
 
     function getTransport(options) {
       if (options.searchApi === 'bulk') {
-        return new BulkTransportFactory(options);
+        return bulkTransport;
       }
-      return new HttpPostTransportFactory(options);
+      return httpPostTransport;
     }
   });
 
@@ -1607,7 +1609,8 @@ angular.module('o19s.splainer-search')
               currRequest.defered.reject(resp);
               // individual query failure
             } else {
-              currRequest.defered.resolve(resp);
+              // make the response look like standard response
+              currRequest.defered.resolve({'data': resp});
             }
 
             queueIdx++;

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1587,6 +1587,7 @@ angular.module('o19s.splainer-search')
       var requestConfig = {headers: headers};
       var self = this;
       self.enqueue = enqueue;
+      self.url = getUrl;
       var queue = [];
       var pendingHttp = null;
 
@@ -1640,7 +1641,7 @@ angular.module('o19s.splainer-search')
             queryLines.push(JSON.stringify(pendingQuery.payload));
           });
           var data = queryLines.join('\n');
-          pendingHttp = $http.post(url, data, requestConfig);
+          pendingHttp = $http.post(url, data + '\n', requestConfig);
           pendingHttp.then(dequeue, allFailed);
         }
       }
@@ -1662,6 +1663,10 @@ angular.module('o19s.splainer-search')
         $timeout(timerTick, 100);
       }
 
+      function getUrl() {
+        return url;
+      }
+
       $timeout(timerTick, 100);
 
 
@@ -1680,6 +1685,9 @@ angular.module('o19s.splainer-search')
     function query(url, payload, headers) {
       var self = this;
       if (!self.bulkTransporter) {
+        self.bulkTransporter = new BulkTransporter(url, headers);
+      }
+      else if (self.bulkTransporter.url() !== url) {
         self.bulkTransporter = new BulkTransporter(url, headers);
       }
       return self.bulkTransporter.enqueue(payload);

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1598,71 +1598,85 @@ angular.module('o19s.splainer-search')
         queue = queue.slice(batchSize);
       }
 
-      function dequeue(httpResp) {
+      function multiSearchSuccess(httpResp) {
+        // Examine the responses and dequeue the corresponding
+        // searches
         var bulkHttpResp = httpResp.data;
         if (bulkHttpResp.hasOwnProperty('responses'))  {
-          var queueIdx = 0;
           var respLen = bulkHttpResp.responses.length;
-          angular.forEach(bulkHttpResp.responses, function(resp) {
-            var currRequest = queue[queueIdx];
-            if (resp.hasOwnProperty('error')) {
-              currRequest.defered.reject(resp);
-              // individual query failure
-            } else {
-              // make the response look like standard response
-              currRequest.defered.resolve({'data': resp});
-            }
-
-            queueIdx++;
-          });
+          dequeuePendingSearches(bulkHttpResp);
           finishBatch(respLen);
         } else {
-          allFailed(bulkHttpResp);
+          multiSearchFailed(bulkHttpResp);
         }
       }
 
-      function allFailed(bulkHttpResp) {
+      function multiSearchFailed(bulkHttpResp) {
         var numInFlight = 0;
         angular.forEach(queue, function(pendingQuery) {
           if (pendingQuery.inFlight) {
             pendingQuery.defered.reject(bulkHttpResp);
-            // fail them
             numInFlight++;
           }
         });
         finishBatch(numInFlight);
       }
 
-      function tryHttp() {
+      function buildMultiSearch() {
+        // Batch queued searches into one message using MultiSearch API
+        // https://www.elastic.co/guide/en/elasticsearch/reference/1.4/search-multi-search.html
+        var sharedHeader = JSON.stringify({});
+        var queryLines = [];
+        angular.forEach(queue, function(pendingQuery) {
+          queryLines.push(sharedHeader);
+          pendingQuery.inFlight = true;
+          queryLines.push(JSON.stringify(pendingQuery.payload));
+        });
+        var data = queryLines.join('\n') + '\n';
+        return data;
+      }
+
+      function dequeuePendingSearches(bulkHttpResp) {
+        // Examine the responses and dequeue the corresponding
+        // searches
+        var queueIdx = 0;
+        angular.forEach(bulkHttpResp.responses, function(resp) {
+          var currRequest = queue[queueIdx];
+          if (resp.hasOwnProperty('error')) {
+            currRequest.defered.reject(resp);
+            // individual query failure
+          } else {
+            // make the response look like standard response
+            currRequest.defered.resolve({'data': resp});
+          }
+
+          queueIdx++;
+        });
+      }
+
+      function sendMultiSearch() {
         if (!pendingHttp && queue.length > 0) {
           // Implementation of Elasticsearch's _msearch ("Multi Search") API
-          var sharedHeader = JSON.stringify({}); // means use inde
-          var queryLines = [];
-          angular.forEach(queue, function(pendingQuery) {
-            queryLines.push(sharedHeader);
-            pendingQuery.inFlight = true;
-            queryLines.push(JSON.stringify(pendingQuery.payload));
-          });
-          var data = queryLines.join('\n');
-          pendingHttp = $http.post(url, data + '\n', requestConfig);
-          pendingHttp.then(dequeue, allFailed);
+          var payload = buildMultiSearch();
+          pendingHttp = $http.post(url, payload, requestConfig);
+          pendingHttp.then(multiSearchSuccess, multiSearchFailed);
         }
       }
 
-      function enqueue(payload) {
+      function enqueue(query) {
         var defered = $q.defer();
 
         var pendingQuery = {
           defered: defered,
           inFlight: false,
-          payload: payload,
+          payload: query,
         };
         queue.push(pendingQuery);
         return defered.promise;
       }
 
       function timerTick() {
-        tryHttp();
+        sendMultiSearch();
         $timeout(timerTick, 100);
       }
 

--- a/test/spec/bulkTransportFactory.js
+++ b/test/spec/bulkTransportFactory.js
@@ -130,7 +130,7 @@ describe('Service: transport: es bulk transport', function() {
 
     var indivSuccessCheck = function(requestIdx) {
       return function(results) {
-        expect(results).toEqual(mockResults.responses[requestIdx]);
+        expect(results.data).toEqual(mockResults.responses[requestIdx]);
         promisesResolved++;
       };
     };
@@ -171,7 +171,7 @@ describe('Service: transport: es bulk transport', function() {
 
     var indivSuccessCheck = function(requestIdx) {
       return function(results) {
-        expect(results).toEqual(mockResults.responses[requestIdx]);
+        expect(results.data).toEqual(mockResults.responses[requestIdx]);
         promisesResolved++;
       };
     };
@@ -216,7 +216,7 @@ describe('Service: transport: es bulk transport', function() {
 
     var indivSuccessCheck = function(requestIdx) {
       return function(results) {
-        expect(results).toEqual(mockResults.responses[requestIdx]);
+        expect(results.date).toEqual(mockResults.responses[requestIdx]);
         promisesResolved++;
       };
     };
@@ -261,7 +261,7 @@ describe('Service: transport: es bulk transport', function() {
 
     var indivSuccessCheck = function(requestIdx) {
       return function(results) {
-        expect(results).toEqual(mockResults.responses[requestIdx]);
+        expect(results.data).toEqual(mockResults.responses[requestIdx]);
         promisesResolved++;
       };
     };

--- a/test/spec/bulkTransportFactory.js
+++ b/test/spec/bulkTransportFactory.js
@@ -299,6 +299,23 @@ describe('Service: transport: es bulk transport', function() {
     .respond(200, mockResults);
     $timeout.flush();
     $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
     expect(promisesResolved).toBe(numToQuery * 2);
+  });
+
+  it('doesnt issue http if nothing to send', function () {
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var headers = {'header': 1};
+    var bulkTransport = new BulkTransportFactory();
+    var payloadTemplate = {'test': 0};
+    var payload = angular.copy(payloadTemplate);
+    var mockResults = buildMockResults(1);
+    bulkTransport.query(url, payload, headers);
+    $httpBackend.expectPOST(url).respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $timeout.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
   });
 });

--- a/test/spec/bulkTransportFactory.js
+++ b/test/spec/bulkTransportFactory.js
@@ -1,0 +1,304 @@
+'use strict';
+
+/*global describe,beforeEach,inject,it,expect*/
+describe('Service: transport: es bulk transport', function() {
+  // load the service's module
+  beforeEach(module('o19s.splainer-search'));
+
+  var $httpBackend;
+  var $q;
+  var $rootScope;
+  var $timeout;
+  var BulkTransportFactory;
+
+  beforeEach(inject(function (_BulkTransportFactory_) {
+    BulkTransportFactory = _BulkTransportFactory_;
+  }));
+
+  beforeEach(inject(function($injector) {
+    $httpBackend = $injector.get('$httpBackend');
+    $q = $injector.get('$q');
+    $rootScope = $injector.get('$rootScope');
+    $timeout = $injector.get('$timeout');
+  }));
+
+  var mockResultsTemplate = {
+    hits: {
+      total: 2,
+      'max_score': 1.0,
+      hits: [
+        {
+        }
+      ]
+    }
+  };
+
+  var mockResultsErrorTemplate = {
+    error: 'Error for query'
+  };
+
+  var buildMockResults = function(howMany) {
+    var i = 0;
+    var results = {'responses': []};
+    for (i = 0; i < howMany; i++) {
+      var mockResults = angular.copy(mockResultsTemplate);
+      mockResults.hits.total = i;
+      results.responses[i] = mockResults;
+    }
+    return results;
+  };
+
+  var hasExpectedJsonList = function(expectedObjects) {
+    return {
+      test: function(textSent) {
+        var sentObjs = textSent.split('\n');
+        if (sentObjs.length !== expectedObjects.length) {
+          return false;
+        }
+        else {
+          var i = 0;
+          for (i = 0; i < sentObjs.length; i++) {
+            var ithObj = JSON.parse(sentObjs[i]);
+            if (!angular.equals(expectedObjects[i], ithObj)) {
+              return false;
+            }
+          }
+        }
+        return true;
+
+      }
+    };
+  };
+
+  var containsExpectedHeaders = function(expectedHeaders) {
+    return function(headerSent) {
+        angular.forEach(expectedHeaders, function(headerValue, headerKey) {
+          if (!headerSent.hasOwnProperty(headerKey)) {
+            return false;
+          } else if (headerSent[headerKey] !== headerValue) {
+            return false;
+          }
+        });
+        return true;
+      };
+  };
+
+  it('sends whats in queue after timeout', function () {
+    var bulkTransport = new BulkTransportFactory();
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var payloadTemplate = {'test': 0};
+    var headers = {'header': 1};
+
+    // queue a bunch of messages
+    var expectedObjects = [];
+    var i = 0;
+    var numToQuery = 10;
+    for (i = 0; i < numToQuery; i++) {
+      var payload = angular.copy(payloadTemplate);
+      payload.test = i;
+      bulkTransport.query(url, payload, headers);
+      expectedObjects.push({});
+      expectedObjects.push(payload);
+    }
+
+    var mockResults = buildMockResults(numToQuery);
+
+    $httpBackend.expectPOST(url,
+                            hasExpectedJsonList(expectedObjects), containsExpectedHeaders(headers))
+    .respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+  });
+
+
+  it('resolves whats in flight', function () {
+    var bulkTransport = new BulkTransportFactory();
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var payloadTemplate = {'test': 0};
+    var headers = {'header': 1};
+
+    // queue a bunch of messages
+    var expectedObjects = [];
+    var i = 0;
+    var numToQuery = 10;
+    var promisesResolved = 0;
+    var mockResults = buildMockResults(numToQuery);
+
+    var indivSuccessCheck = function(requestIdx) {
+      return function(results) {
+        expect(results).toEqual(mockResults.responses[requestIdx]);
+        promisesResolved++;
+      };
+    };
+
+    for (i = 0; i < numToQuery; i++) {
+      var payload = angular.copy(payloadTemplate);
+      payload.test = i;
+      bulkTransport.query(url, payload, headers).then(indivSuccessCheck(i));
+      expectedObjects.push({});
+      expectedObjects.push(payload);
+    }
+
+
+    $httpBackend.expectPOST(url,
+                            hasExpectedJsonList(expectedObjects), containsExpectedHeaders(headers))
+    .respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    expect(promisesResolved).toBe(numToQuery);
+  });
+
+  it('rejects individual errors', function () {
+    var bulkTransport = new BulkTransportFactory();
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var payloadTemplate = {'test': 0};
+    var headers = {'header': 1};
+
+    // queue a bunch of messages
+    var expectedObjects = [];
+    var i = 0;
+    var numToQuery = 10;
+    var promisesResolved = 0;
+    var promisesRejected = 0;
+    var mockResults = buildMockResults(numToQuery);
+    mockResults.responses[2] = angular.copy(mockResultsErrorTemplate);
+    mockResults.responses[4] = angular.copy(mockResultsErrorTemplate);
+
+    var indivSuccessCheck = function(requestIdx) {
+      return function(results) {
+        expect(results).toEqual(mockResults.responses[requestIdx]);
+        promisesResolved++;
+      };
+    };
+
+    var indivErrorCheck = function(requestIdx) {
+      return function(results) {
+        expect(results).toEqual(mockResults.responses[requestIdx]);
+        promisesRejected++;
+      };
+    };
+
+    for (i = 0; i < numToQuery; i++) {
+      var payload = angular.copy(payloadTemplate);
+      payload.test = i;
+      bulkTransport.query(url, payload, headers).then(indivSuccessCheck(i), indivErrorCheck(i));
+      expectedObjects.push({});
+      expectedObjects.push(payload);
+    }
+
+
+    $httpBackend.expectPOST(url,
+                            hasExpectedJsonList(expectedObjects), containsExpectedHeaders(headers))
+    .respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    expect(promisesResolved).toBe(8);
+    expect(promisesRejected).toBe(2);
+  });
+
+  it('rejects all on http errors', function () {
+    var bulkTransport = new BulkTransportFactory();
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var payloadTemplate = {'test': 0};
+    var headers = {'header': 1};
+
+    var expectedObjects = [];
+    var numToQuery = 10;
+    var promisesResolved = 0;
+    var promisesRejected = 0;
+    var mockResults = buildMockResults(numToQuery);
+
+    var indivSuccessCheck = function(requestIdx) {
+      return function(results) {
+        expect(results).toEqual(mockResults.responses[requestIdx]);
+        promisesResolved++;
+      };
+    };
+
+    var indivErrorCheck = function() {
+      return function() {
+        promisesRejected++;
+      };
+    };
+
+    for (var i = 0; i < numToQuery; i++) {
+      var payload = angular.copy(payloadTemplate);
+      payload.test = i;
+      bulkTransport.query(url, payload, headers).then(indivSuccessCheck(i), indivErrorCheck(i));
+      expectedObjects.push({});
+      expectedObjects.push(payload);
+    }
+
+    $httpBackend.expectPOST(url,
+                            hasExpectedJsonList(expectedObjects), containsExpectedHeaders(headers))
+    .respond(400, {});
+    $timeout.flush();
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    expect(promisesResolved).toBe(0);
+    expect(promisesRejected).toBe(numToQuery);
+
+  });
+
+  it('bulks requests serially', function () {
+    var bulkTransport = new BulkTransportFactory();
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var payloadTemplate = {'test': 0};
+    var headers = {'header': 1};
+
+    // queue a bunch of messages
+    var expectedObjects = [];
+    var i = 0;
+    var numToQuery = 10;
+    var promisesResolved = 0;
+    var mockResults = buildMockResults(numToQuery);
+
+    var indivSuccessCheck = function(requestIdx) {
+      return function(results) {
+        expect(results).toEqual(mockResults.responses[requestIdx]);
+        promisesResolved++;
+      };
+    };
+
+    var payload = {};
+    for (i = 0; i < numToQuery; i++) {
+      payload = angular.copy(payloadTemplate);
+      payload.test = i;
+      bulkTransport.query(url, payload, headers).then(indivSuccessCheck(i));
+      expectedObjects.push({});
+      expectedObjects.push(payload);
+    }
+
+
+    $httpBackend.expectPOST(url,
+                            hasExpectedJsonList(expectedObjects), containsExpectedHeaders(headers))
+    .respond(200, mockResults);
+    $timeout.flush();
+
+    var expectedObjectsBatch2 = [];
+    // append further to the queue in addition to some that are in flight,
+    // only
+    for (i = 0; i < numToQuery; i++) {
+      payload = angular.copy(payloadTemplate);
+      payload.test = numToQuery + i;
+      bulkTransport.query(url, payload, headers).then(indivSuccessCheck(i));
+      expectedObjectsBatch2.push({});
+      expectedObjectsBatch2.push(payload);
+    }
+
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    expect(promisesResolved).toBe(numToQuery);
+
+    // put the second batch in flight,
+    // verify they came back
+    $httpBackend.expectPOST(url,
+                            hasExpectedJsonList(expectedObjectsBatch2), containsExpectedHeaders(headers))
+    .respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.flush();
+    expect(promisesResolved).toBe(numToQuery * 2);
+  });
+});

--- a/test/spec/bulkTransportFactory.js
+++ b/test/spec/bulkTransportFactory.js
@@ -51,6 +51,10 @@ describe('Service: transport: es bulk transport', function() {
   var hasExpectedJsonList = function(expectedObjects) {
     return {
       test: function(textSent) {
+        if (!textSent.endsWith('\n')) {
+          return false;
+        }
+        textSent = textSent.substring(0, textSent.length - 1);
         var sentObjs = textSent.split('\n');
         if (sentObjs.length !== expectedObjects.length) {
           return false;
@@ -317,5 +321,47 @@ describe('Service: transport: es bulk transport', function() {
     $httpBackend.verifyNoOutstandingExpectation();
     $timeout.flush();
     $httpBackend.verifyNoOutstandingExpectation();
+  });
+
+  it('adds a trailing \n', function () {
+
+    var trailingEndlineTest = {
+      test: function(data) {
+        return data.endsWith('\n');
+      }
+    };
+
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var headers = {'header': 1};
+    var bulkTransport = new BulkTransportFactory();
+    var payloadTemplate = {'test': 0};
+    var payload = angular.copy(payloadTemplate);
+    var mockResults = buildMockResults(1);
+    bulkTransport.query(url, payload, headers);
+    $httpBackend.expectPOST(url, trailingEndlineTest).respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+  });
+
+
+  it('changes URLs', function () {
+    var url = 'http://es.splainer-search.com/foods/tacos/_msearch';
+    var headers = {'header': 1};
+    var bulkTransport = new BulkTransportFactory();
+    var payloadTemplate = {'test': 0};
+    var payload = angular.copy(payloadTemplate);
+    var mockResults = buildMockResults(1);
+    bulkTransport.query(url, payload, headers);
+    $httpBackend.expectPOST(url).respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+
+    var url2 = 'http://es2.splainer-search.com/foods/tacos/_msearch';
+    bulkTransport.query(url2, payload, headers);
+    $httpBackend.expectPOST(url2).respond(200, mockResults);
+    $timeout.flush();
+    $httpBackend.flush();
   });
 });

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -449,6 +449,15 @@ describe('Service: searchSvc: ElasticSearch', function() {
       );
     }));
 
+    function pagerValidator(expectedPagerParams) {
+      return {
+        test: function(data) {
+          var data = JSON.parse(data);
+          return (data.from === expectedPagerParams.from) && (data.size === expectedPagerParams.size);
+        }
+      }
+    };
+
     it('pages on page', function() {
       $httpBackend.expectPOST(mockEsUrl).respond(200, fullResponse);
 
@@ -462,7 +471,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
         from: 10
       };
 
-      $httpBackend.expectPOST(mockEsUrl + '?from=10&size=10')
+      $httpBackend.expectPOST(mockEsUrl, pagerValidator(expectedPageParams))
         .respond(200, fullResponse);
 
       nextSearcher.search();
@@ -472,10 +481,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
       nextSearcher = nextSearcher.pager();
       expectedPageParams = {
         size: 10,
-        from: 21
+        from: 20
       };
 
-      $httpBackend.expectPOST(mockEsUrl + '?from=20&size=10')
+      $httpBackend.expectPOST(mockEsUrl, pagerValidator(expectedPageParams))
         .respond(200, fullResponse);
 
       nextSearcher.search();

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -105,6 +105,26 @@ describe('Service: searchSvc: ElasticSearch', function() {
       expect(called).toEqual(1);
     });
 
+    it('reports errors for the search', function() {
+      var errorMsg = 'your query just plain stunk';
+      $httpBackend.expectPOST(mockEsUrl).
+      respond(400, errorMsg);
+
+      var errorCalled = 0;
+
+      searcher.search()
+      .then(function success() {
+        errorCalled--;
+      }, function failure(msg) {
+        expect(msg.data).toBe(errorMsg);
+        errorCalled++;
+      });
+
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+      expect(errorCalled).toEqual(1);
+    });
+
     it('sets the proper headers for auth', function() {
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -60,6 +60,20 @@ describe('Service: esUrlSvc', function () {
       expect(uri.username).toBe('username');
       expect(uri.password).toBe('password');
     });
+
+    it('understands when bulk endpoint used', function() {
+      var url = 'http://es.quepid.com/tmdb/_search';
+      var uri = esUrlSvc.parseUrl(url);
+      expect(uri.searchApi).toBe('post');
+
+      url = 'http://es.quepid.com/tmdb/_msearch';
+      uri = esUrlSvc.parseUrl(url);
+      expect(uri.searchApi).toBe('bulk');
+
+      url = 'http://es.quepid.com/tmdb/_msearch/';
+      uri = esUrlSvc.parseUrl(url);
+      expect(uri.searchApi).toBe('bulk');
+    });
   });
 
   describe('build doc URL', function() {

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -13,52 +13,52 @@ describe('Service: esUrlSvc', function () {
   describe('parse URL', function() {
     it('extracts the different parts of a URL', function() {
       var url = 'http://localhost:9200/tmdb/_search';
-      esUrlSvc.parseUrl(url);
+      var uri = esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('http');
-      expect(esUrlSvc.host).toBe('localhost:9200');
-      expect(esUrlSvc.pathname).toBe('/tmdb/_search');
+      expect(uri.protocol).toBe('http');
+      expect(uri.host).toBe('localhost:9200');
+      expect(uri.pathname).toBe('/tmdb/_search');
 
-      var url = 'http://es.quepid.com/tmdb/_search';
-      esUrlSvc.parseUrl(url);
+      url = 'http://es.quepid.com/tmdb/_search';
+      uri = esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('http');
-      expect(esUrlSvc.host).toBe('es.quepid.com');
-      expect(esUrlSvc.pathname).toBe('/tmdb/_search');
+      expect(uri.protocol).toBe('http');
+      expect(uri.host).toBe('es.quepid.com');
+      expect(uri.pathname).toBe('/tmdb/_search');
 
-      var url = 'https://es.quepid.com/tmdb/_search';
-      esUrlSvc.parseUrl(url);
+      url = 'https://es.quepid.com/tmdb/_search';
+      uri = esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('https');
-      expect(esUrlSvc.host).toBe('es.quepid.com');
-      expect(esUrlSvc.pathname).toBe('/tmdb/_search');
+      expect(uri.protocol).toBe('https');
+      expect(uri.host).toBe('es.quepid.com');
+      expect(uri.pathname).toBe('/tmdb/_search');
     });
 
     it('adds http if the protocol is missing', function() {
       var url = 'localhost:9200/tmdb/_search';
-      esUrlSvc.parseUrl(url);
+      var uri = esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.protocol).toBe('http');
+      expect(uri.protocol).toBe('http');
     });
 
     it('retrieves the username and password if available', function() {
       var url = 'http://es.quepid.com/tmdb/_search';
-      esUrlSvc.parseUrl(url);
+      var uri = esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.username).toBe('');
-      expect(esUrlSvc.password).toBe('');
+      expect(uri.username).toBe('');
+      expect(uri.password).toBe('');
 
-      var url = 'http://username:password@es.quepid.com/tmdb/_search';
-      esUrlSvc.parseUrl(url);
+      url = 'http://username:password@es.quepid.com/tmdb/_search';
+      uri = esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.username).toBe('username');
-      expect(esUrlSvc.password).toBe('password');
+      expect(uri.username).toBe('username');
+      expect(uri.password).toBe('password');
 
-      var url = 'http://username:password@localhost:9200/tmdb/_search';
-      esUrlSvc.parseUrl(url);
+      url = 'http://username:password@localhost:9200/tmdb/_search';
+      uri = esUrlSvc.parseUrl(url);
 
-      expect(esUrlSvc.username).toBe('username');
-      expect(esUrlSvc.password).toBe('password');
+      expect(uri.username).toBe('username');
+      expect(uri.password).toBe('password');
     });
   });
 
@@ -69,14 +69,15 @@ describe('Service: esUrlSvc', function () {
       _index: 'tmdb',
       _type:  'movies',
       _id:    '1'
-    }
+    };
 
+    var uri = null;
     beforeEach( function () {
-      esUrlSvc.parseUrl(url);
+      uri = esUrlSvc.parseUrl(url);
     });
 
     it('builds a proper doc URL from the doc info', function() {
-      var docUrl = esUrlSvc.buildDocUrl(doc);
+      var docUrl = esUrlSvc.buildDocUrl(uri, doc);
 
       expect(docUrl).toBe('http://localhost:9200/tmdb/movies/1');
     });
@@ -85,34 +86,35 @@ describe('Service: esUrlSvc', function () {
   describe('build URL', function() {
     var url = 'http://localhost:9200/tmdb/_search';
 
+    var uri = null;
     beforeEach( function () {
-      esUrlSvc.parseUrl(url);
+      uri = esUrlSvc.parseUrl(url);
     });
 
     it('returns the original URL if no params are passed', function() {
-      var returnedUrl = esUrlSvc.buildUrl();
+      var returnedUrl = esUrlSvc.buildUrl(uri);
 
       expect(returnedUrl).toBe(url);
     });
 
     it('returns the original URL if params passed is empty', function() {
       var params = { };
-      esUrlSvc.setParams(params);
-      var returnedUrl = esUrlSvc.buildUrl();
+      esUrlSvc.setParams(uri, params);
+      var returnedUrl = esUrlSvc.buildUrl(uri);
 
       expect(returnedUrl).toBe(url);
     });
 
     it('appends params to the original URL', function() {
-      var params = { foo: "bar" };
-      esUrlSvc.setParams(params);
-      var returnedUrl = esUrlSvc.buildUrl();
+      var params = { foo: 'bar' };
+      esUrlSvc.setParams(uri, params);
+      var returnedUrl = esUrlSvc.buildUrl(uri);
 
       expect(returnedUrl).toBe(url + '?foo=bar');
 
-      var params = { foo: "bar", bar: "foo" };
-      esUrlSvc.setParams(params);
-      var returnedUrl = esUrlSvc.buildUrl();
+      params = { foo: 'bar', bar: 'foo' };
+      esUrlSvc.setParams(uri, params);
+      returnedUrl = esUrlSvc.buildUrl(uri);
 
       expect(returnedUrl).toBe(url + '?foo=bar&bar=foo');
     });


### PR DESCRIPTION
## Changelog

If the URL ends in _msearch, use the [Multi-search API](https://www.elastic.co/guide/en/elasticsearch/reference/1.4/search-multi-search.html) otherwise continue to POST single search requests. This helps this library interoperate with certain Elasticsearch hosts that limit the number of concurrent HTTP requests.

To do this, we introduce the idea of a "transport" that the searcher uses to send its message. The default transport is only a few lines and just issues an HTTP post. The more complex bulk transport batches requests in a queue and sends them serially using the multisearch API.

This should open up the possibility of implementing other ways of talking to the search engine, such as
- Solr GET instead of JSONP if the user has CORS setup
- ES's weird GET with a body 
