### PR TITLE
Return ES errors when the response is a success but the search contains errors.

### DIFF
--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -170,6 +170,10 @@
           var doc = parseDoc(hit);
           thisSearcher.docs.push(doc);
         });
+
+        if ( angular.isDefined(data._shards) && data._shards.failed > 0 ) {
+          return $q.reject(data._shards.failures[0]);
+        }
       }, function error(msg) {
         activeQueries.count--;
         thisSearcher.inError = true;

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2045,6 +2045,10 @@ angular.module('o19s.splainer-search')
           var doc = parseDoc(hit);
           thisSearcher.docs.push(doc);
         });
+
+        if ( angular.isDefined(data._shards) && data._shards.failed > 0 ) {
+          return $q.reject(data._shards.failures[0]);
+        }
       }, function error(msg) {
         activeQueries.count--;
         thisSearcher.inError = true;


### PR DESCRIPTION
Sometimes ES returns a `failures` array inside the `_shards` object of the response, yet still considers the request a success.
This would create a scenario where it looks to the user that everything was fine, but does not return the array of results inside the `hits.hits` object.
So in this case we reject the promise and return the appropriate error response.
