### PR TITLE
Settings validator builds a list of candidate id fields

### DIFF
--- a/factories/settingsValidatorFactory.js
+++ b/factories/settingsValidatorFactory.js
@@ -71,9 +71,6 @@
       function validateUrl () {
         return self.searcher.search()
         .then(function () {
-          if (self.searchEngine === 'es') {
-            self.fields.push('_id');
-          }
           var candidateIds;
 
           // Merge fields from multiple docs because some docs might not return
@@ -89,6 +86,10 @@
             }));
           });
           self.idFields = candidateIds;
+          if (self.searchEngine === 'es') {
+            self.fields.unshift('_id');
+            self.idFields.unshift('_id');
+          }
         });
       }
     };

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2286,6 +2286,7 @@ angular.module('o19s.splainer-search')
 
       self.searcher = null;
       self.fields   = [];
+      self.idFields = [];
 
       self.setupSearcher  = setupSearcher;
       self.validateUrl    = validateUrl;
@@ -2312,30 +2313,50 @@ angular.module('o19s.splainer-search')
         );
       }
 
+      function sourceDoc(doc) {
+        if ( self.searchEngine === 'solr' ) {
+          return doc.doc;
+        } else if (self.searchEngine === 'es') {
+          return doc.doc._source;
+        }
+      }
+
+      function intersection(a, b) {
+        var intersect = a.filter(function(aVal) {
+          return b.indexOf(aVal) !== -1;
+        });
+        return intersect;
+      }
+
+      function updateCandidateIds(candidateIds, attributes) {
+        if (angular.isUndefined(candidateIds)) {
+          return attributes;
+        }
+        // Guarantee that the candidateIds set occurs in every field
+        return intersection(candidateIds, attributes);
+      }
+
       function validateUrl () {
         return self.searcher.search()
         .then(function () {
+          var candidateIds;
+
           // Merge fields from multiple docs because some docs might not return
           // the entire list of fields possible.
           // This is not perfect as the top 10 results might not include
           // a comprehensive list, but it's the best we can do.
-          if ( self.searchEngine === 'solr' ) {
-            angular.forEach(self.searcher.docs, function(doc) {
-              var attributes = Object.keys(doc.doc);
+          angular.forEach(self.searcher.docs, function(doc) {
+            var attributes = Object.keys(sourceDoc(doc));
+            candidateIds = updateCandidateIds(candidateIds, attributes);
 
-              self.fields = self.fields.concat(attributes.filter(function (attribute) {
-                return self.fields.indexOf(attribute) < 0;
-              }));
-            });
-          } else if ( self.searchEngine === 'es' ) {
-            self.fields.push('_id');
-
-            angular.forEach(self.searcher.docs, function(doc) {
-              var attributes = Object.keys(doc.doc._source);
-              self.fields = self.fields.concat(attributes.filter(function (attribute) {
-                return self.fields.indexOf(attribute) < 0;
-              }));
-            });
+            self.fields = self.fields.concat(attributes.filter(function (attribute) {
+              return self.fields.indexOf(attribute) < 0;
+            }));
+          });
+          self.idFields = candidateIds;
+          if (self.searchEngine === 'es') {
+            self.fields.unshift('_id');
+            self.idFields.unshift('_id');
           }
         });
       }

--- a/test/spec/settingsValidatorFactory.js
+++ b/test/spec/settingsValidatorFactory.js
@@ -56,9 +56,67 @@ describe('Factory: Settings Validator', function () {
         ]
       }
     };
+    var funkyDocs =
+      [
+        {
+          "id":"l_5552",
+          "text":"For purposes of computing.",
+          "section":"9.1-703",
+          "structure":"Commonwealth Public Safety/Overtime Compensation for Law-Enforcement Employees and Firefighters, Emergency Medical Technicians,",
+          "type":"law",
+          'uid': "1234",
+          "_version_":1512671587453632512
+        },
+        {
+          "catch_line":"Powers, duties and responsibilities of the Inspector.",
+          "text":"foo",
+          "section":"45.1-361.28",
+          "structure":"Mines and Mining/The Virginia Gas and Oil Act",
+          "tags":["locality"],
+          "refers_to":["45.1-161.5"],
+          "type":"law",
+          'uid': "1235",
+          "_version_":1512671587500818432
+        },
+        {
+          "id":"l_5552",
+          "text":"For purposes of computing.",
+          "section":"9.1-703",
+          'uid': "1236",
+          "_version_":1512671587453632512
+        }
+
+        ];
 
     beforeEach( function () {
       validator = new SettingsValidatorFactory(settings);
+    });
+
+    describe('Generates candidate ids', function() {
+      it('selects only ids occuring across all docs', function() {
+        var expectedParams = {
+          q: ['*:*'],
+        };
+
+        var funkyResponse = angular.copy(fullResponse);
+        funkyResponse.response.docs = funkyDocs
+        $httpBackend.expectJSONP(urlContainsParams(settings.searchUrl, expectedParams))
+          .respond(200, funkyResponse);
+
+        var called = 0;
+        validator.validateUrl()
+        .then(function() {
+          called++;
+          expect(validator.idFields.length).toBe(4);
+          expect(validator.idFields).toContain('uid')
+          expect(validator.idFields).toContain('text')
+          expect(validator.idFields).toContain('section')
+          expect(validator.idFields).toContain('_version_')
+        });
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        expect(called).toBe(1);
+      });
     });
 
     describe('Validate URL:', function () {

--- a/test/spec/settingsValidatorFactory.js
+++ b/test/spec/settingsValidatorFactory.js
@@ -93,7 +93,35 @@ describe('Factory: Settings Validator', function () {
     });
 
     describe('Generates candidate ids', function() {
-      it('selects only ids occuring across all docs', function() {
+
+      it('selects only ids occuring across all docs, bland docs', function() {
+          var expectedParams = {
+            q: ['*:*'],
+          };
+
+          $httpBackend.expectJSONP(urlContainsParams(settings.searchUrl, expectedParams))
+            .respond(200, fullResponse);
+
+          var called = 0;
+          validator.validateUrl()
+          .then(function() {
+            expect(validator.idFields.length).toBe(7);
+            expect(validator.idFields).toContain('id')
+            expect(validator.idFields).toContain('text')
+            expect(validator.idFields).toContain('catch_line')
+            expect(validator.idFields).toContain('section')
+            expect(validator.idFields).toContain('type')
+            expect(validator.idFields).toContain('structure')
+            expect(validator.idFields).toContain('_version_')
+            called++;
+          });
+
+          $httpBackend.flush();
+          $httpBackend.verifyNoOutstandingExpectation();
+          expect(called).toBe(1);
+      });
+
+      it('selects only ids occuring across all docs, funkier docs', function() {
         var expectedParams = {
           q: ['*:*'],
         };
@@ -116,6 +144,9 @@ describe('Factory: Settings Validator', function () {
         $httpBackend.flush();
         $httpBackend.verifyNoOutstandingExpectation();
         expect(called).toBe(1);
+      });
+
+      it('selects only ids occuring across all docs, funkier docs', function() {
       });
     });
 
@@ -212,6 +243,32 @@ describe('Factory: Settings Validator', function () {
 
     beforeEach( function () {
       validator = new SettingsValidatorFactory(settings);
+    });
+
+    describe('Generates candidate ids', function() {
+
+      it('selects only ids occuring across all docs', function() {
+          var expectedParams = {
+            q: ['*:*'],
+          };
+
+          $httpBackend.expectPOST(settings.searchUrl).respond(200, fullResponse);
+
+          var called = 0;
+          validator.validateUrl()
+          .then(function() {
+            expect(validator.idFields.length).toBe(3);
+            expect(validator.idFields).toContain('id')
+            expect(validator.idFields).toContain('_id')
+            expect(validator.idFields).toContain('title')
+            called++;
+          });
+
+          $httpBackend.flush();
+          $httpBackend.verifyNoOutstandingExpectation();
+          expect(called).toBe(1);
+      });
+
     });
 
     describe('Validate URL:', function () {


### PR DESCRIPTION
## Changelog

In addition to just "fields" this creates a list of candidate ID fields based on currently one requirement (a candidate id field must be present on every document). This is intended to prevent the selection of the wrong id field, thus prevent all sorts of confusing Quepid behavior.
## Acceptance Criteria

see related Quepid issue
