### PR TITLE
Allows using #$queryN## in dev settings to represent Nth keyword

### DIFF
--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -13,7 +13,7 @@ angular.module('o19s.splainer-search')
 
       var replaced  = angular.toJson(args, true);
 
-      replaced      = queryTemplateSvc.hydrate(replaced, queryText);
+      replaced      = queryTemplateSvc.hydrate(replaced, queryText, {encodeURI: false, defaultKw: '\\"\\"'});
       replaced      = angular.fromJson(replaced);
 
       return replaced;

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('o19s.splainer-search')
-  .service('esSearcherPreprocessorSvc', function esSearcherPreprocessorSvc() {
+  .service('esSearcherPreprocessorSvc', function esSearcherPreprocessorSvc(queryTemplateSvc) {
     var self      = this;
     self.prepare  = prepare;
 
@@ -12,7 +12,8 @@ angular.module('o19s.splainer-search')
       }
 
       var replaced  = angular.toJson(args, true);
-      replaced      = replaced.replace(/#\$query##/g, queryText);
+
+      replaced      = queryTemplateSvc.hydrate(replaced, queryText);
       replaced      = angular.fromJson(replaced);
 
       return replaced;

--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -23,7 +23,7 @@ angular.module('o19s.splainer-search')
       var maxKeywords = 10;
       var numTerms = queryTerms.length;
       for (var i = numTerms; i < maxKeywords; i++) {
-        queryTerms.push('');
+        queryTerms.push(null);
       }
       return queryTerms;
     }
@@ -33,11 +33,21 @@ angular.module('o19s.splainer-search')
         config = defaultConfig;
       }
 
+      if (queryText === null || angular.isUndefined(queryText)) {
+        return template;
+      }
+
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
+      var defaultKwReplacement = '';
       angular.forEach(keywordMapping(queryText), function(queryTerm) {
         var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
-        replaced = replaced.replace(regex, encode(queryTerm, config));
+        if (queryTerm === null) {
+          queryTerm = defaultKwReplacement;
+        } else {
+          queryTerm = encode(queryTerm, config);
+        }
+        replaced = replaced.replace(regex, queryTerm);
         idx += 1;
       });
       return replaced;

--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -41,7 +41,7 @@ angular.module('o19s.splainer-search')
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
       angular.forEach(keywordMapping(queryText), function(queryTerm) {
-        var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
+        var regex = new RegExp('#\\$keyword' + (idx + 1) + '##', 'g');
         if (queryTerm === null) {
           queryTerm = config.defaultKw;
         } else {

--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -6,7 +6,8 @@ angular.module('o19s.splainer-search')
     self.hydrate = hydrate;
 
     var defaultConfig = {
-      encodeURI: false
+      encodeURI: false,
+      defaultKw: '""',
     };
 
     function encode(queryPart, config) {
@@ -39,11 +40,10 @@ angular.module('o19s.splainer-search')
 
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
-      var defaultKwReplacement = '';
       angular.forEach(keywordMapping(queryText), function(queryTerm) {
         var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
         if (queryTerm === null) {
-          queryTerm = defaultKwReplacement;
+          queryTerm = config.defaultKw;
         } else {
           queryTerm = encode(queryTerm, config);
         }

--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -1,0 +1,30 @@
+'use strict';
+
+angular.module('o19s.splainer-search')
+  .service('queryTemplateSvc', function queryTemplateSvc() {
+    var self      = this;
+    self.hydrate = hydrate;
+
+    var defaultConfig = {
+      encodeURI: true
+    };
+
+    function encode(queryPart, config) {
+      if (config.encodeURI) {
+        return encodeURIComponent(queryPart);
+      } else {
+        return queryPart;
+      }
+    }
+
+    function hydrate(template, queryText, config) {
+      if (!config) {
+        config = defaultConfig;
+      }
+
+      //var queryTerms    = queryText.split(/[ ,]+/);
+      var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
+      console.log(replaced);
+      return replaced;
+    }
+  });

--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -17,14 +17,29 @@ angular.module('o19s.splainer-search')
       }
     }
 
+
+    function keywordMapping(queryText) {
+      var queryTerms    = queryText.split(/[ ,]+/);
+      var maxKeywords = 10;
+      var numTerms = queryTerms.length;
+      for (var i = numTerms; i < maxKeywords; i++) {
+        queryTerms.push('');
+      }
+      return queryTerms;
+    }
+
     function hydrate(template, queryText, config) {
       if (!config) {
         config = defaultConfig;
       }
 
-      //var queryTerms    = queryText.split(/[ ,]+/);
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
-      console.log(replaced);
+      var idx = 0;
+      angular.forEach(keywordMapping(queryText), function(queryTerm) {
+        var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
+        replaced = replaced.replace(regex, encode(queryTerm, config));
+        idx += 1;
+      });
       return replaced;
     }
   });

--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -6,7 +6,7 @@ angular.module('o19s.splainer-search')
     self.hydrate = hydrate;
 
     var defaultConfig = {
-      encodeURI: true
+      encodeURI: false
     };
 
     function encode(queryPart, config) {

--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -18,10 +18,24 @@ angular.module('o19s.splainer-search')
       }
     }
 
+    function getMaxKeywords(template) {
+      var keywordMatch = /#\$keyword(\d)##/g;
+      var match = keywordMatch.exec(template);
+      var maxKw = 0;
+      while (match !== null) {
+        var kwNum = parseInt(match[1]);
+        if (kwNum) {
+          if (kwNum > maxKw) {
+            maxKw = kwNum;
+          }
+        }
+        match = keywordMatch.exec(template);
+      }
+      return maxKw;
+    }
 
-    function keywordMapping(queryText) {
+    function keywordMapping(queryText, maxKeywords) {
       var queryTerms    = queryText.split(/[ ,]+/);
-      var maxKeywords = 10;
       var numTerms = queryTerms.length;
       for (var i = numTerms; i < maxKeywords; i++) {
         queryTerms.push(null);
@@ -40,7 +54,8 @@ angular.module('o19s.splainer-search')
 
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
-      angular.forEach(keywordMapping(queryText), function(queryTerm) {
+      var maxKeywords = getMaxKeywords(template);
+      angular.forEach(keywordMapping(queryText, maxKeywords), function(queryTerm) {
         var regex = new RegExp('#\\$keyword' + (idx + 1) + '##', 'g');
         if (queryTerm === null) {
           queryTerm = config.defaultKw;

--- a/services/solrSearcherPreprocessorSvc.js
+++ b/services/solrSearcherPreprocessorSvc.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('o19s.splainer-search')
-  .service('solrSearcherPreprocessorSvc', function solrSearcherPreprocessorSvc(solrUrlSvc, defaultSolrConfig) {
+  .service('solrSearcherPreprocessorSvc', function solrSearcherPreprocessorSvc(solrUrlSvc, defaultSolrConfig, queryTemplateSvc) {
     var self      = this;
     self.prepare  = prepare;
 
@@ -42,7 +42,7 @@ angular.module('o19s.splainer-search')
       }
 
       var baseUrl = solrUrlSvc.buildUrl(url, args);
-      baseUrl = baseUrl.replace(/#\$query##/g, encodeURIComponent(queryText));
+      baseUrl = queryTemplateSvc.hydrate(baseUrl, queryText, {encodeURI: true});
 
       return baseUrl;
     };

--- a/services/solrSearcherPreprocessorSvc.js
+++ b/services/solrSearcherPreprocessorSvc.js
@@ -42,7 +42,7 @@ angular.module('o19s.splainer-search')
       }
 
       var baseUrl = solrUrlSvc.buildUrl(url, args);
-      baseUrl = queryTemplateSvc.hydrate(baseUrl, queryText, {encodeURI: true});
+      baseUrl = queryTemplateSvc.hydrate(baseUrl, queryText, {encodeURI: true, defaultKw: '""'});
 
       return baseUrl;
     };

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -163,7 +163,7 @@ angular.module('o19s.splainer-search')
 'use strict';
 
 angular.module('o19s.splainer-search')
-  .service('esSearcherPreprocessorSvc', function esSearcherPreprocessorSvc() {
+  .service('esSearcherPreprocessorSvc', function esSearcherPreprocessorSvc(queryTemplateSvc) {
     var self      = this;
     self.prepare  = prepare;
 
@@ -174,7 +174,8 @@ angular.module('o19s.splainer-search')
       }
 
       var replaced  = angular.toJson(args, true);
-      replaced      = replaced.replace(/#\$query##/g, queryText);
+
+      replaced      = queryTemplateSvc.hydrate(replaced, queryText);
       replaced      = angular.fromJson(replaced);
 
       return replaced;
@@ -1037,6 +1038,52 @@ angular.module('o19s.splainer-search')
 
 'use strict';
 
+angular.module('o19s.splainer-search')
+  .service('queryTemplateSvc', function queryTemplateSvc() {
+    var self      = this;
+    self.hydrate = hydrate;
+
+    var defaultConfig = {
+      encodeURI: false
+    };
+
+    function encode(queryPart, config) {
+      if (config.encodeURI) {
+        return encodeURIComponent(queryPart);
+      } else {
+        return queryPart;
+      }
+    }
+
+
+    function keywordMapping(queryText) {
+      var queryTerms    = queryText.split(/[ ,]+/);
+      var maxKeywords = 10;
+      var numTerms = queryTerms.length;
+      for (var i = numTerms; i < maxKeywords; i++) {
+        queryTerms.push('');
+      }
+      return queryTerms;
+    }
+
+    function hydrate(template, queryText, config) {
+      if (!config) {
+        config = defaultConfig;
+      }
+
+      var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
+      var idx = 0;
+      angular.forEach(keywordMapping(queryText), function(queryTerm) {
+        var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
+        replaced = replaced.replace(regex, encode(queryTerm, config));
+        idx += 1;
+      });
+      return replaced;
+    }
+  });
+
+'use strict';
+
 // Executes a solr search and returns
 // a set of solr documents
 angular.module('o19s.splainer-search')
@@ -1231,7 +1278,7 @@ angular.module('o19s.splainer-search')
 'use strict';
 
 angular.module('o19s.splainer-search')
-  .service('solrSearcherPreprocessorSvc', function solrSearcherPreprocessorSvc(solrUrlSvc, defaultSolrConfig) {
+  .service('solrSearcherPreprocessorSvc', function solrSearcherPreprocessorSvc(solrUrlSvc, defaultSolrConfig, queryTemplateSvc) {
     var self      = this;
     self.prepare  = prepare;
 
@@ -1272,7 +1319,7 @@ angular.module('o19s.splainer-search')
       }
 
       var baseUrl = solrUrlSvc.buildUrl(url, args);
-      baseUrl = baseUrl.replace(/#\$query##/g, encodeURIComponent(queryText));
+      baseUrl = queryTemplateSvc.hydrate(baseUrl, queryText, {encodeURI: true});
 
       return baseUrl;
     };

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -175,7 +175,7 @@ angular.module('o19s.splainer-search')
 
       var replaced  = angular.toJson(args, true);
 
-      replaced      = queryTemplateSvc.hydrate(replaced, queryText);
+      replaced      = queryTemplateSvc.hydrate(replaced, queryText, {encodeURI: false, defaultKw: '\\"\\"'});
       replaced      = angular.fromJson(replaced);
 
       return replaced;
@@ -1044,7 +1044,8 @@ angular.module('o19s.splainer-search')
     self.hydrate = hydrate;
 
     var defaultConfig = {
-      encodeURI: false
+      encodeURI: false,
+      defaultKw: '""',
     };
 
     function encode(queryPart, config) {
@@ -1077,11 +1078,10 @@ angular.module('o19s.splainer-search')
 
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
-      var defaultKwReplacement = '';
       angular.forEach(keywordMapping(queryText), function(queryTerm) {
         var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
         if (queryTerm === null) {
-          queryTerm = defaultKwReplacement;
+          queryTerm = config.defaultKw;
         } else {
           queryTerm = encode(queryTerm, config);
         }
@@ -1329,7 +1329,7 @@ angular.module('o19s.splainer-search')
       }
 
       var baseUrl = solrUrlSvc.buildUrl(url, args);
-      baseUrl = queryTemplateSvc.hydrate(baseUrl, queryText, {encodeURI: true});
+      baseUrl = queryTemplateSvc.hydrate(baseUrl, queryText, {encodeURI: true, defaultKw: '""'});
 
       return baseUrl;
     };

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1061,7 +1061,7 @@ angular.module('o19s.splainer-search')
       var maxKeywords = 10;
       var numTerms = queryTerms.length;
       for (var i = numTerms; i < maxKeywords; i++) {
-        queryTerms.push('');
+        queryTerms.push(null);
       }
       return queryTerms;
     }
@@ -1071,11 +1071,21 @@ angular.module('o19s.splainer-search')
         config = defaultConfig;
       }
 
+      if (queryText === null || angular.isUndefined(queryText)) {
+        return template;
+      }
+
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
+      var defaultKwReplacement = '';
       angular.forEach(keywordMapping(queryText), function(queryTerm) {
         var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
-        replaced = replaced.replace(regex, encode(queryTerm, config));
+        if (queryTerm === null) {
+          queryTerm = defaultKwReplacement;
+        } else {
+          queryTerm = encode(queryTerm, config);
+        }
+        replaced = replaced.replace(regex, queryTerm);
         idx += 1;
       });
       return replaced;

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1056,10 +1056,24 @@ angular.module('o19s.splainer-search')
       }
     }
 
+    function getMaxKeywords(template) {
+      var keywordMatch = /#\$keyword(\d)##/g;
+      var match = keywordMatch.exec(template);
+      var maxKw = 0;
+      while (match !== null) {
+        var kwNum = parseInt(match[1]);
+        if (kwNum) {
+          if (kwNum > maxKw) {
+            maxKw = kwNum;
+          }
+        }
+        match = keywordMatch.exec(template);
+      }
+      return maxKw;
+    }
 
-    function keywordMapping(queryText) {
+    function keywordMapping(queryText, maxKeywords) {
       var queryTerms    = queryText.split(/[ ,]+/);
-      var maxKeywords = 10;
       var numTerms = queryTerms.length;
       for (var i = numTerms; i < maxKeywords; i++) {
         queryTerms.push(null);
@@ -1078,8 +1092,9 @@ angular.module('o19s.splainer-search')
 
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
-      angular.forEach(keywordMapping(queryText), function(queryTerm) {
-        var regex = new RegExp('#\\$query' + (idx + 1) + '##', 'g');
+      var maxKeywords = getMaxKeywords(template);
+      angular.forEach(keywordMapping(queryText, maxKeywords), function(queryTerm) {
+        var regex = new RegExp('#\\$keyword' + (idx + 1) + '##', 'g');
         if (queryTerm === null) {
           queryTerm = config.defaultKw;
         } else {

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -492,6 +492,34 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.flush();
       $httpBackend.verifyNoOutstandingExpectation();
     });
+
+    it('empty query turns to quotes', function() {
+      var mockQueryText = 'purina headphone';
+      var mockEsParams  = {
+        query: {
+          term: {
+            text: '#$query1## #$query3##'
+          }
+        }
+      };
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList,
+        mockEsUrl,
+        mockEsParams,
+        mockQueryText,
+        {},
+        'es'
+      );
+      $httpBackend.expectPOST(mockEsUrl, function verifyDataSent(data) {
+        var esQuery = angular.fromJson(data);
+        console.log(esQuery.query.term.text);
+        return (esQuery.query.term.text === 'purina \"\"');
+      }).
+      respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
   });
 
   describe('paging', function() {

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -465,6 +465,33 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.flush();
       $httpBackend.verifyNoOutstandingExpectation();
     });
+
+    it('null queryText', function() {
+      var mockQueryText = 'taco&burrito purina headphone';
+      var mockEsParams  = {
+        query: {
+          term: {
+            text: 'lovely bunnies'
+          }
+        }
+      };
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList,
+        mockEsUrl,
+        mockEsParams,
+        null,
+        {},
+        'es'
+      );
+      $httpBackend.expectPOST(mockEsUrl, function verifyDataSent(data) {
+        var esQuery = angular.fromJson(data);
+        return (esQuery.query.term.text === 'lovely bunnies');
+      }).
+      respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
   });
 
   describe('paging', function() {

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -444,7 +444,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       var mockEsParams  = {
         query: {
           term: {
-            text: '#$query1## #$query## #$query2##'
+            text: '#$keyword1## #$query## #$keyword2##'
           }
         }
       };
@@ -498,7 +498,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       var mockEsParams  = {
         query: {
           term: {
-            text: '#$query1## #$query3##'
+            text: '#$keyword1## #$keyword3##'
           }
         }
       };

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -411,6 +411,62 @@ describe('Service: searchSvc: ElasticSearch', function() {
     });
   });
 
+  describe('vars', function() {
+    it('replaces vars no URI encode', function() {
+      var mockQueryText = 'taco&burrito';
+      var mockEsParams  = {
+        query: {
+          term: {
+            text: '#$query##'
+          }
+        }
+      };
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList,
+        mockEsUrl,
+        mockEsParams,
+        mockQueryText,
+        {},
+        'es'
+      );
+      $httpBackend.expectPOST(mockEsUrl, function verifyDataSent(data) {
+        var esQuery = angular.fromJson(data);
+        return (esQuery.query.term.text === mockQueryText);
+      }).
+      respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
+    it('replaces keywords vars', function() {
+      var mockQueryText = 'taco&burrito purina headphone';
+      var mockEsParams  = {
+        query: {
+          term: {
+            text: '#$query1## #$query## #$query2##'
+          }
+        }
+      };
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList,
+        mockEsUrl,
+        mockEsParams,
+        mockQueryText,
+        {},
+        'es'
+      );
+      $httpBackend.expectPOST(mockEsUrl, function verifyDataSent(data) {
+        var esQuery = angular.fromJson(data);
+        return (esQuery.query.term.text === 'taco&burrito taco&burrito purina headphone purina');
+      }).
+      respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+  });
+
   describe('paging', function() {
     var fullResponse = {
       hits: {

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -868,7 +868,7 @@ describe('Service: searchSvc: Solr', function () {
     it('does keyword replacement', function() {
       var mockQueryText = 'burrito taco';
       var mockSolrParams = {
-        q: ['#$query1## query #$query2##'],
+        q: ['#$keyword1## query #$keyword2##'],
       };
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco';
@@ -885,7 +885,7 @@ describe('Service: searchSvc: Solr', function () {
     it('extra keyword replacements turns to empty quotes', function() {
       var mockQueryText = 'burrito taco';
       var mockSolrParams = {
-        q: ['#$query1## query #$query2## nothing #$query3##'],
+        q: ['#$keyword1## query #$keyword2## nothing #$keyword3##'],
       };
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco nothing ""';
@@ -902,7 +902,7 @@ describe('Service: searchSvc: Solr', function () {
     it('super long query', function() {
       var mockQueryText = 'burrito taco nacho bbq turkey donkey michelin stream of consciouness taco bell cannot run away from me crazy muhahahaa peanut';
       var mockSolrParams = {
-        q: ['#$query1## query #$query2## nothing #$query3##'],
+        q: ['#$keyword1## query #$keyword2## nothing #$keyword3##'],
       };
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco nothing nacho';

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -898,6 +898,23 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.flush();
       $httpBackend.verifyNoOutstandingExpectation();
     });
+
+    it('super long query', function() {
+      var mockQueryText = 'burrito taco nacho bbq turkey donkey michelin stream of consciouness taco bell cannot run away from me crazy muhahahaa peanut';
+      var mockSolrParams = {
+        q: ['#$query1## query #$query2## nothing #$query3##'],
+      };
+      var expectedParams = angular.copy(mockSolrParams);
+      expectedParams.q[0] = 'burrito query taco nothing nacho';
+
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    })
   });
 
   describe('paging', function() {

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -882,13 +882,13 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
     });
 
-    it('extra keyword replacements go blank', function() {
+    it('extra keyword replacements turns to empty quotes', function() {
       var mockQueryText = 'burrito taco';
       var mockSolrParams = {
         q: ['#$query1## query #$query2## nothing #$query3##'],
       };
       var expectedParams = angular.copy(mockSolrParams);
-      expectedParams.q[0] = 'burrito query taco nothing ';
+      expectedParams.q[0] = 'burrito query taco nothing ""';
 
       var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -847,6 +847,59 @@ describe('Service: searchSvc: Solr', function () {
     });
   });
 
+  describe('vars', function() {
+    it('does full replacement', function() {
+      var mockQueryText = 'burrito taco';
+      var mockSolrParams = {
+        q: ['#$query##'],
+      };
+      var expectedParams = angular.copy(mockSolrParams);
+      expectedParams.q[0] = encodeURIComponent(mockQueryText);
+
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
+    it('does keyword replacement', function() {
+      var mockQueryText = 'burrito taco';
+      var mockSolrParams = {
+        q: ['#$query1## query #$query2##'],
+      };
+      var expectedParams = angular.copy(mockSolrParams);
+      expectedParams.q[0] = 'burrito query taco';
+
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
+    it('extra keyword replacements go blank', function() {
+      var mockQueryText = 'burrito taco';
+      var mockSolrParams = {
+        q: ['#$query1## query #$query2## nothing #$query3##'],
+      };
+      var expectedParams = angular.copy(mockSolrParams);
+      expectedParams.q[0] = 'burrito query taco nothing ';
+
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+  });
+
   describe('paging', function() {
     var fullSolrResp = {'responseHeader':{
       'status':0,


### PR DESCRIPTION
## Changelog

Expands the options on what you can do with query text in the developer settings. Introduces #$queryN## such as #$query1## to represent the first, whitespace delimited. keyword of the query being tested. 
## Acceptance Criteria

In Quepid
- Add query deer hunting
- Query params for Solr:
-  set q=#$query1##, verify you just get deer stuff
-  set q=#$query2##, verify you just get hunting stuff
-  set q="#$query1## $#query2##", verify you get exact "deer hunting" matches
- set q="#$query3##", verify you get no matches (or perhaps all matches, but nothing related to deer or hunting as q should be blank)
