### PR TITLE
Default keyword param

### DIFF
--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -18,10 +18,11 @@ angular.module('o19s.splainer-search')
       }
     }
 
-    function getMaxKeywords(template) {
-      var keywordMatch = /#\$keyword(\d)##/g;
+    function getKeywordDefaults(template, config) {
+      var keywordMatch = /#\$keyword(\d)(\|.*?){0,1}##/g;
       var match = keywordMatch.exec(template);
       var maxKw = 0;
+      var defaults = [];
       while (match !== null) {
         var kwNum = parseInt(match[1]);
         if (kwNum) {
@@ -29,9 +30,16 @@ angular.module('o19s.splainer-search')
             maxKw = kwNum;
           }
         }
+        var def = match[2];
+        if (def) {
+          defaults[kwNum] = def.slice(1);
+        }
+        else {
+          defaults[kwNum] = config.defaultKw;
+        }
         match = keywordMatch.exec(template);
       }
-      return maxKw;
+      return defaults;
     }
 
     function keywordMapping(queryText, maxKeywords) {
@@ -54,11 +62,16 @@ angular.module('o19s.splainer-search')
 
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
-      var maxKeywords = getMaxKeywords(template);
+      var defaults = getKeywordDefaults(template, config);
+      var maxKeywords = defaults.length;
       angular.forEach(keywordMapping(queryText, maxKeywords), function(queryTerm) {
-        var regex = new RegExp('#\\$keyword' + (idx + 1) + '##', 'g');
+        var regex = new RegExp('#\\$keyword' + (idx + 1) + '(.*?)##', 'g');
+        var def = defaults[idx + 1];
+        if (angular.isUndefined(def)) {
+          def = config.defaultKw;
+        }
         if (queryTerm === null) {
-          queryTerm = config.defaultKw;
+          queryTerm = def;
         } else {
           queryTerm = encode(queryTerm, config);
         }

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1056,10 +1056,11 @@ angular.module('o19s.splainer-search')
       }
     }
 
-    function getMaxKeywords(template) {
-      var keywordMatch = /#\$keyword(\d)##/g;
+    function getKeywordDefaults(template, config) {
+      var keywordMatch = /#\$keyword(\d)(\|.*?){0,1}##/g;
       var match = keywordMatch.exec(template);
       var maxKw = 0;
+      var defaults = [];
       while (match !== null) {
         var kwNum = parseInt(match[1]);
         if (kwNum) {
@@ -1067,9 +1068,16 @@ angular.module('o19s.splainer-search')
             maxKw = kwNum;
           }
         }
+        var def = match[2];
+        if (def) {
+          defaults[kwNum] = def.slice(1);
+        }
+        else {
+          defaults[kwNum] = config.defaultKw;
+        }
         match = keywordMatch.exec(template);
       }
-      return maxKw;
+      return defaults;
     }
 
     function keywordMapping(queryText, maxKeywords) {
@@ -1092,11 +1100,16 @@ angular.module('o19s.splainer-search')
 
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
       var idx = 0;
-      var maxKeywords = getMaxKeywords(template);
+      var defaults = getKeywordDefaults(template, config);
+      var maxKeywords = defaults.length;
       angular.forEach(keywordMapping(queryText, maxKeywords), function(queryTerm) {
-        var regex = new RegExp('#\\$keyword' + (idx + 1) + '##', 'g');
+        var regex = new RegExp('#\\$keyword' + (idx + 1) + '(.*?)##', 'g');
+        var def = defaults[idx + 1];
+        if (angular.isUndefined(def)) {
+          def = config.defaultKw;
+        }
         if (queryTerm === null) {
-          queryTerm = config.defaultKw;
+          queryTerm = def;
         } else {
           queryTerm = encode(queryTerm, config);
         }

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -899,6 +899,23 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
     });
 
+    it('custom defaults', function() {
+      var mockQueryText = 'burrito taco';
+      var mockSolrParams = {
+        q: ['#$keyword1## query #$keyword2## nothing #$keyword3|someDefault##'],
+      };
+      var expectedParams = angular.copy(mockSolrParams);
+      expectedParams.q[0] = 'burrito query taco nothing someDefault';
+
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
     it('super long query', function() {
       var mockQueryText = 'burrito taco nacho bbq turkey donkey michelin stream of consciouness taco bell cannot run away from me crazy muhahahaa peanut';
       var mockSolrParams = {


### PR DESCRIPTION
## Changelog

Allows specification of a default for keyword variables with the syntax #$keyword3|default## in the query template.

The reason we do this is to allow for defaults that match up with the query syntax. For example, the default for the keyword search "" break things.
