### PR TITLE
Allows default per kw var

### DIFF
--- a/services/queryTemplateSvc.js
+++ b/services/queryTemplateSvc.js
@@ -19,7 +19,7 @@ angular.module('o19s.splainer-search')
     }
 
     function getMaxKws(template) {
-      var keywordMatch = /#\$keyword(\d)(\|.*?){0,1}##/g;
+      var keywordMatch = /#\$keyword\d|(.*?)##/g;
       var match = keywordMatch.exec(template);
       var maxKw = 0;
       while (match !== null) {
@@ -47,7 +47,7 @@ angular.module('o19s.splainer-search')
       // Though its possible this link gets out of link, this was the origin
       // of the regex below
       // http://www.regexpal.com/?fam=93576
-      replaced = replaced.replace(/#\$keyword\d(\|(.*?)){1}##/g, '$2'); // regex
+      replaced = replaced.replace(/#\$keyword\d\|(.*?)##/g, '$1'); // regex
       // anything left, use config defaults
       replaced = replaced.replace(/#\$keyword\d(\|(.*?)){0,1}##/g, config.defaultKw); // regex
       return replaced;

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1056,11 +1056,10 @@ angular.module('o19s.splainer-search')
       }
     }
 
-    function getKeywordDefaults(template, config) {
+    function getMaxKws(template) {
       var keywordMatch = /#\$keyword(\d)(\|.*?){0,1}##/g;
       var match = keywordMatch.exec(template);
       var maxKw = 0;
-      var defaults = [];
       while (match !== null) {
         var kwNum = parseInt(match[1]);
         if (kwNum) {
@@ -1068,16 +1067,9 @@ angular.module('o19s.splainer-search')
             maxKw = kwNum;
           }
         }
-        var def = match[2];
-        if (def) {
-          defaults[kwNum] = def.slice(1);
-        }
-        else {
-          defaults[kwNum] = config.defaultKw;
-        }
         match = keywordMatch.exec(template);
       }
-      return defaults;
+      return maxKw;
     }
 
     function keywordMapping(queryText, maxKeywords) {
@@ -1087,6 +1079,29 @@ angular.module('o19s.splainer-search')
         queryTerms.push(null);
       }
       return queryTerms;
+    }
+
+    function hydrateWithKwDefaults(replaced, config) {
+      // Though its possible this link gets out of link, this was the origin
+      // of the regex below
+      // http://www.regexpal.com/?fam=93576
+      replaced = replaced.replace(/#\$keyword\d(\|(.*?)){1}##/g, '$2'); // regex
+      // anything left, use config defaults
+      replaced = replaced.replace(/#\$keyword\d(\|(.*?)){0,1}##/g, config.defaultKw); // regex
+      return replaced;
+    }
+
+    function hydrateWithKws(replaced, queryText, maxKws, config) {
+      var idx = 0;
+      angular.forEach(keywordMapping(queryText, maxKws), function(queryTerm) {
+        var regex = new RegExp('#\\$keyword' + (idx + 1) + '(.*?)##', 'g');
+        if (queryTerm !== null) {
+          queryTerm = encode(queryTerm, config);
+          replaced = replaced.replace(regex, queryTerm);
+        }
+        idx += 1;
+      });
+      return replaced;
     }
 
     function hydrate(template, queryText, config) {
@@ -1099,23 +1114,10 @@ angular.module('o19s.splainer-search')
       }
 
       var replaced  = template.replace(/#\$query##/g, encode(queryText, config));
-      var idx = 0;
-      var defaults = getKeywordDefaults(template, config);
-      var maxKeywords = defaults.length;
-      angular.forEach(keywordMapping(queryText, maxKeywords), function(queryTerm) {
-        var regex = new RegExp('#\\$keyword' + (idx + 1) + '(.*?)##', 'g');
-        var def = defaults[idx + 1];
-        if (angular.isUndefined(def)) {
-          def = config.defaultKw;
-        }
-        if (queryTerm === null) {
-          queryTerm = def;
-        } else {
-          queryTerm = encode(queryTerm, config);
-        }
-        replaced = replaced.replace(regex, queryTerm);
-        idx += 1;
-      });
+      var maxKws = getMaxKws(template, config);
+      replaced = hydrateWithKws(replaced, queryText, maxKws, config);
+      replaced = hydrateWithKwDefaults(replaced, config);
+
       return replaced;
     }
   });

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1057,7 +1057,7 @@ angular.module('o19s.splainer-search')
     }
 
     function getMaxKws(template) {
-      var keywordMatch = /#\$keyword(\d)(\|.*?){0,1}##/g;
+      var keywordMatch = /#\$keyword\d|(.*?)##/g;
       var match = keywordMatch.exec(template);
       var maxKw = 0;
       while (match !== null) {
@@ -1085,7 +1085,7 @@ angular.module('o19s.splainer-search')
       // Though its possible this link gets out of link, this was the origin
       // of the regex below
       // http://www.regexpal.com/?fam=93576
-      replaced = replaced.replace(/#\$keyword\d(\|(.*?)){1}##/g, '$2'); // regex
+      replaced = replaced.replace(/#\$keyword\d\|(.*?)##/g, '$1'); // regex
       // anything left, use config defaults
       replaced = replaced.replace(/#\$keyword\d(\|(.*?)){0,1}##/g, config.defaultKw); // regex
       return replaced;

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -916,6 +916,23 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
     });
 
+    it('many custom defaults', function() {
+      var mockQueryText = 'burrito taco';
+      var mockSolrParams = {
+        q: ['#$keyword1## query #$keyword2## nothing #$keyword3|someDefault## #$keyword3|otherDefaults## #$keyword2##'],
+      };
+      var expectedParams = angular.copy(mockSolrParams);
+      expectedParams.q[0] = 'burrito query taco nothing someDefault otherDefaults taco';
+
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
     it('super long query', function() {
       var mockQueryText = 'burrito taco nacho bbq turkey donkey michelin stream of consciouness taco bell cannot run away from me crazy muhahahaa peanut';
       var mockSolrParams = {

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -933,6 +933,23 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
     });
 
+    it('many custom defaults, others not customized', function() {
+      var mockQueryText = 'burrito taco';
+      var mockSolrParams = {
+        q: ['#$keyword1## query #$keyword2## nothing #$keyword3|someDefault## #$keyword3|otherDefaults## #$keyword3## #$keyword2##'],
+      };
+      var expectedParams = angular.copy(mockSolrParams);
+      expectedParams.q[0] = 'burrito query taco nothing someDefault otherDefaults "" taco';
+
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(200, mockResults);
+      searcher.search();
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
     it('super long query', function() {
       var mockQueryText = 'burrito taco nacho bbq turkey donkey michelin stream of consciouness taco bell cannot run away from me crazy muhahahaa peanut';
       var mockSolrParams = {


### PR DESCRIPTION
## Changelog

I made a mistake when I implemented the keyword vars. When the user uses
"#$keyword3|def1## #$keyword3|def2##" only the first default is picked
up and used as a default for keyword3. The intention was for each
instance of a missign keyword to be able to have its own default. The
reason being that depending on where you sprinkle that keyword in the
query structure, it may impact how the Lucene query is parsed if a
keyword is missing. IE the Solr default of "" would end up screwing up a
phrase query. However something like "" would be an ok default in a
Lucene query.
