### PR TITLE
Improved Elasticsearch explanation parsing/display

### DIFF
--- a/services/explainSvc.js
+++ b/services/explainSvc.js
@@ -19,6 +19,8 @@ angular.module('o19s.splainer-search')
       var SumExplain = queryExplainSvc.SumExplain;
       var CoordExplain = queryExplainSvc.CoordExplain;
       var ProductExplain = queryExplainSvc.ProductExplain;
+      var MinExplain = queryExplainSvc.MinExplain;
+      var EsFunctionQueryExplain = queryExplainSvc.EsFunctionQueryExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -95,6 +97,10 @@ angular.module('o19s.splainer-search')
           FunctionQueryExplain.prototype = base;
           return new FunctionQueryExplain(explJson);
         }
+        else if (description.startsWith('Function ')) {
+          EsFunctionQueryExplain.prototype = base;
+          return new EsFunctionQueryExplain(explJson);
+        }
         else if (tieMatch && tieMatch.length > 1) {
           var tie = parseFloat(tieMatch[1]);
           DismaxTieExplain.prototype = base;
@@ -107,6 +113,10 @@ angular.module('o19s.splainer-search')
         else if (description.hasSubstr('sum of')) {
           SumExplain.prototype = base;
           return meOrOnlyChild(new SumExplain(explJson));
+        }
+        else if (description.hasSubstr('Math.min of')) {
+          MinExplain.prototype = base;
+          return meOrOnlyChild(new MinExplain(explJson));
         }
         else if (description.hasSubstr('product of')) {
           var coordExpl = null;

--- a/services/explainSvc.js
+++ b/services/explainSvc.js
@@ -20,7 +20,7 @@ angular.module('o19s.splainer-search')
       var CoordExplain = queryExplainSvc.CoordExplain;
       var ProductExplain = queryExplainSvc.ProductExplain;
       var MinExplain = queryExplainSvc.MinExplain;
-      var EsFunctionQueryExplain = queryExplainSvc.EsFunctionQueryExplain;
+      var EsFieldFunctionQueryExplain = queryExplainSvc.EsFieldFunctionQueryExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -97,9 +97,9 @@ angular.module('o19s.splainer-search')
           FunctionQueryExplain.prototype = base;
           return new FunctionQueryExplain(explJson);
         }
-        else if (description.startsWith('Function ')) {
-          EsFunctionQueryExplain.prototype = base;
-          return new EsFunctionQueryExplain(explJson);
+        else if (description.startsWith('Function for field')) {
+          EsFieldFunctionQueryExplain.prototype = base;
+          return new EsFieldFunctionQueryExplain(explJson);
         }
         else if (tieMatch && tieMatch.length > 1) {
           var tie = parseFloat(tieMatch[1]);

--- a/services/queryExplainSvc.js
+++ b/services/queryExplainSvc.js
@@ -78,6 +78,39 @@ angular.module('o19s.splainer-search')
         }
       };
 
+      this.EsFunctionQueryExplain = function() {
+        this.realExplanation = this.description;
+
+        this.influencers = function() {
+          return this.children;
+        };
+
+        this.vectorize = function() {
+          var rVal = vectorSvc.create();
+          angular.forEach(this.influencers(), function(infl) {
+            rVal = vectorSvc.add(rVal, infl.vectorize());
+          });
+          return rVal;
+        };
+      };
+
+      this.MinExplain = function() {
+        this.realExplaination = 'Minimum Of:';
+
+        this.influencers = function() {
+          var infl = shallowArrayCopy(this.children);
+          infl.sort(function(a, b) {return a.score - b.score;});
+          return [infl[0]];
+        };
+
+        this.vectorize = function() {
+          // pick the minimum, which is sorted by influencers
+          var infl = this.influencers();
+          var minInfl = infl[0];
+          return minInfl.vectorize();
+          };
+      };
+
       this.CoordExplain = function(explJson, coordFactor) {
         if (coordFactor < 1.0) {
           this.realExplanation = 'Matches Punished by ' + coordFactor + ' (not all query terms matched)';
@@ -107,7 +140,7 @@ angular.module('o19s.splainer-search')
       };
 
       this.DismaxTieExplain = function(explJson, tie) {
-        this.realExplanation = 'Dismax (max plus:' + tie + ' times others';
+        this.realExplanation = 'Dismax (max plus:' + tie + ' times others)';
 
         this.influencers = function() {
           var infl = shallowArrayCopy(this.children);

--- a/services/queryExplainSvc.js
+++ b/services/queryExplainSvc.js
@@ -78,20 +78,20 @@ angular.module('o19s.splainer-search')
         }
       };
 
-      this.EsFunctionQueryExplain = function() {
-        this.realExplanation = this.description;
+      this.EsFieldFunctionQueryExplain = function(explJson) {
+        var funcQueryRegex = /Function for field (.*?):/;
+        var description = explJson.description;
+        var match = description.match(funcQueryRegex);
+        var fieldName = 'unknown';
+        if (match !== null && match.length > 1) {
+          fieldName = match[1];
+        }
+        var explText = 'f(' + fieldName + ') = ';
+        angular.forEach(this.children, function(child) {
+          explText += child.description + ' ';
+        });
+        this.realExplanation = explText;
 
-        this.influencers = function() {
-          return this.children;
-        };
-
-        this.vectorize = function() {
-          var rVal = vectorSvc.create();
-          angular.forEach(this.influencers(), function(infl) {
-            rVal = vectorSvc.add(rVal, infl.vectorize());
-          });
-          return rVal;
-        };
       };
 
       this.MinExplain = function() {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -354,7 +354,7 @@ angular.module('o19s.splainer-search')
       var CoordExplain = queryExplainSvc.CoordExplain;
       var ProductExplain = queryExplainSvc.ProductExplain;
       var MinExplain = queryExplainSvc.MinExplain;
-      var EsFunctionQueryExplain = queryExplainSvc.EsFunctionQueryExplain;
+      var EsFieldFunctionQueryExplain = queryExplainSvc.EsFieldFunctionQueryExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -431,9 +431,9 @@ angular.module('o19s.splainer-search')
           FunctionQueryExplain.prototype = base;
           return new FunctionQueryExplain(explJson);
         }
-        else if (description.startsWith('Function ')) {
-          EsFunctionQueryExplain.prototype = base;
-          return new EsFunctionQueryExplain(explJson);
+        else if (description.startsWith('Function for field')) {
+          EsFieldFunctionQueryExplain.prototype = base;
+          return new EsFieldFunctionQueryExplain(explJson);
         }
         else if (tieMatch && tieMatch.length > 1) {
           var tie = parseFloat(tieMatch[1]);
@@ -923,20 +923,20 @@ angular.module('o19s.splainer-search')
         }
       };
 
-      this.EsFunctionQueryExplain = function() {
-        this.realExplanation = this.description;
+      this.EsFieldFunctionQueryExplain = function(explJson) {
+        var funcQueryRegex = /Function for field (.*?):/;
+        var description = explJson.description;
+        var match = description.match(funcQueryRegex);
+        var fieldName = 'unknown';
+        if (match !== null && match.length > 1) {
+          fieldName = match[1];
+        }
+        var explText = 'f(' + fieldName + ') = ';
+        angular.forEach(this.children, function(child) {
+          explText += child.description + ' ';
+        });
+        this.realExplanation = explText;
 
-        this.influencers = function() {
-          return this.children;
-        };
-
-        this.vectorize = function() {
-          var rVal = vectorSvc.create();
-          angular.forEach(this.influencers(), function(infl) {
-            rVal = vectorSvc.add(rVal, infl.vectorize());
-          });
-          return rVal;
-        };
       };
 
       this.MinExplain = function() {

--- a/test/mock/esExplain.js
+++ b/test/mock/esExplain.js
@@ -1,0 +1,77 @@
+esExplain = {
+        "value": 0.039659735,
+        "description": "function score, product of:",
+        "details": [{
+          "value": 1.1995022,
+          "description": "product of:",
+          "details": [{
+            "value": 1.5993363,
+            "description": "sum of:",
+            "details": [{
+              "value": 0.74043345,
+              "description": "max of:",
+              "details": [{
+                "value": 0.74043345,
+                "description": "weight(text:foo^10.0 in 6351) [PerFieldSimilarity], result of:",
+                "details": [{
+                  "value": 0.74043345,
+                  "description": "score(doc=6351,freq=1.0), product of:",
+                  "details": [{
+                    "value": 0.28293502,
+                    "description": "queryWeight, product of:",
+                    "details": [{
+                      "value": 10.0,
+                      "description": "boost"
+                    }, {
+                      "value": 8.374315,
+                      "description": "idf(docFreq=7, maxDocs=12756)"
+                    }, {
+                      "value": 0.003378605,
+                      "description": "queryNorm"
+                    }]
+                  }, {
+                    "value": 2.6169734,
+                    "description": "fieldWeight in 6351, product of:",
+                    "details": [{
+                      "value": 1.0,
+                      "description": "tf(freq=1.0), with freq of:",
+                      "details": [{
+                        "value": 1.0,
+                        "description": "termFreq=1.0"
+                      }]
+                    }, {
+                      "value": 8.374315,
+                      "description": "idf(docFreq=7, maxDocs=12756)"
+                    }, {
+                      "value": 0.3125,
+                      "description": "fieldNorm(doc=6351)"
+                    }]
+                  }]
+                }]
+              }]
+            }]
+          }, {
+            "value": 0.75,
+            "description": "coord(3/4)"
+          }]
+        }, {
+          "value": 0.033063494,
+          "description": "Math.min of",
+          "details": [{
+            "value": 0.033063494,
+            "description": "Function for field created_at:",
+            "details": [{
+              "value": 0.033063494,
+              "description": "exp(- MIN[Math.max(Math.abs(1.399894202E12(=doc value) - 1.450890423697E12(=origin))) - 0.0(=offset), 0)] * 6.68544734336367E-11)"
+            }]
+          }, {
+            "value": 3.4028235E38,
+            "description": "maxBoost"
+          }]
+        }, {
+          "value": 1.0,
+          "description": "queryBoost"
+        }]
+      }
+
+

--- a/test/spec/explainSvc.js
+++ b/test/spec/explainSvc.js
@@ -26,7 +26,7 @@ describe('Service: explainSvc', function () {
   it('how does it perform', function() {
     var d = new Date();
     var start = d.getTime();
-    
+
     /*global bigHonkinExplain*/
     for (var i = 0; i <10; i++) {
       var simplerExplain = explainSvc.createExplain(bigHonkinExplain);
@@ -52,19 +52,19 @@ describe('Service: explainSvc', function () {
           value: 0.5,
           description: 'part 1 is 0.5',
           details: []
-        },    
+        },
         {
           match: true,
           value: 0.3,
           description: 'part 2 is 0.3',
           details: []
-        },    
+        },
         {
           match: true,
           value: 0.7,
           description: 'part 3 is 0.7',
           details: []
-        }    
+        }
       ]
     };
     var simplerExplain = explainSvc.createExplain(sumExplain);
@@ -91,27 +91,27 @@ describe('Service: explainSvc', function () {
               value: 0.2,
               description: 'part 1a is 0.2',
               details: []
-            },    
+            },
             {
               match: true,
               value: 0.3,
               description: 'part 1b is 0.3',
               details: []
-            }    
+            }
           ]
-        },    
+        },
         {
           match: true,
           value: 0.1,
           description: 'part 2 is 0.1',
           details: []
-        },    
+        },
         {
           match: true,
           value: 0.7,
           description: 'part 3 is 0.7',
           details: []
-        }    
+        }
       ]
     };
     var simplerExplain = explainSvc.createExplain(sumOfSumExplain);
@@ -121,6 +121,39 @@ describe('Service: explainSvc', function () {
     expect(infl[1].description).toEqual('part 1b is 0.3');
     expect(infl[2].description).toEqual('part 1a is 0.2');
     expect(infl[3].description).toEqual('part 2 is 0.1');
+  });
+
+  describe('elaticsearch explains', function() {
+    // Elasticsearch explain
+
+    it('deals with Math.minOf', function() {
+      /*global esExplain*/
+      var minOfExpl = {
+          'value': 0.033063494,
+          'description': 'Math.min of',
+          'details': [{
+            'value': 0.033063494,
+            'description': 'Function for field created_at:',
+            'details': [{
+              'value': 0.033063494,
+              'description': 'exp(- MIN[Math.max(Math.abs(1.399894202E12(=doc value) - 1.450890423697E12(=origin))) - 0.0(=offset), 0)] * 6.68544734336367E-11)'
+            }]
+          }, {
+            'value': 3.4028235E38,
+            'description': 'maxBoost'
+          }]
+        };
+      var simplerExplain = explainSvc.createExplain(minOfExpl);
+      var infl = simplerExplain.influencers();
+
+      expect(infl.length).toEqual(1);
+
+      var matches = simplerExplain.vectorize();
+      expect(Object.keys(matches.vecObj).length).toBe(1); // get down to just the function query
+      expect(Object.keys(matches.vecObj)[0]).toContain('exp'); // get down to just the function query
+    });
+
+
   });
 
   describe('weird explains', function() {
@@ -136,22 +169,22 @@ describe('Service: explainSvc', function () {
           value: 0.5,
           description: 'part 1 is 0.5',
           details: []
-        },    
+        },
         {
           match: true,
           value: 0.3,
           description: 'part 2 is 0.3',
           details: []
-        },    
+        },
         {
           match: true,
           value: 0.7,
           description: 'part 3 is 0.7',
           details: []
-        }    
+        }
       ]
     };
-    
+
     it('vectorize empty', function() {
       var expl = explainSvc.createExplain(weirdExplain);
       expect(expl.vectorize().get('Weird thing matched')).toEqual(1.5);


### PR DESCRIPTION
Improvements to how Elatsicsearch explains are parsed/displayed
- Ignore spurious "Math.min ofs" that show up in the explain, delegating to lower levels in the explain
- field value factor function queries dig into the function queries below
