### PR TITLE
Allows display of Solr function query results per document

### DIFF
--- a/services/fieldSpecSvc.js
+++ b/services/fieldSpecSvc.js
@@ -4,6 +4,14 @@ angular.module('o19s.splainer-search')
   .service('fieldSpecSvc', [
     function fieldSpecSvc() {
       var addFieldOfType = function(fieldSpec, fieldType, fieldName) {
+        if (fieldType === 'function') {
+          // a function query function:foo is really foo:$foo
+          fieldType = 'sub';
+          if (fieldName.startsWith('$')) {
+            fieldName = fieldName.slice(1);
+          }
+          fieldName = fieldName + ':$' + fieldName;
+        }
         if (fieldType === 'sub') {
           if (!fieldSpec.hasOwnProperty('subs')) {
             fieldSpec.subs = [];
@@ -21,6 +29,13 @@ angular.module('o19s.splainer-search')
         fieldSpec.fields.push(fieldName);
       };
 
+      var normalizeFieldTypeAliases = function(fieldType) {
+        if (fieldType === 'func' || fieldType === 'f') {
+          return 'function';
+        }
+        return fieldType;
+      };
+
       // Populate field spec from a field spec string
       var populateFieldSpec = function(fieldSpec, fieldSpecStr) {
         var fieldSpecs = fieldSpecStr.split('+').join(' ').split(/[\s,]+/);
@@ -29,7 +44,7 @@ angular.module('o19s.splainer-search')
           var fieldType = null;
           var fieldName = null;
           if (typeAndField.length === 2) {
-            fieldType = typeAndField[0];
+            fieldType = normalizeFieldTypeAliases(typeAndField[0]);
             fieldName = typeAndField[1];
           }
           else if (typeAndField.length === 1) {

--- a/services/fieldSpecSvc.js
+++ b/services/fieldSpecSvc.js
@@ -5,12 +5,15 @@ angular.module('o19s.splainer-search')
     function fieldSpecSvc() {
       var addFieldOfType = function(fieldSpec, fieldType, fieldName) {
         if (fieldType === 'function') {
+          if (!fieldSpec.hasOwnProperty('functions')) {
+            fieldSpec.functions = [];
+          }
           // a function query function:foo is really foo:$foo
-          fieldType = 'sub';
           if (fieldName.startsWith('$')) {
             fieldName = fieldName.slice(1);
           }
           fieldName = fieldName + ':$' + fieldName;
+          fieldSpec.functions.push(fieldName);
         }
         if (fieldType === 'sub') {
           if (!fieldSpec.hasOwnProperty('subs')) {
@@ -97,6 +100,9 @@ angular.module('o19s.splainer-search')
           }
           angular.forEach(this.subs, function(sub) {
             innerBody(sub);
+          });
+          angular.forEach(this.functions, function(func) {
+            innerBody(func);
           });
         };
       };

--- a/services/normalDocSvc.js
+++ b/services/normalDocSvc.js
@@ -29,11 +29,12 @@ angular.module('o19s.splainer-search')
         }
       };
 
-      var assignFields = function(normalDoc, doc, fieldSpec) {
-        assignSingleField(normalDoc, doc, fieldSpec.id, 'id');
-        assignSingleField(normalDoc, doc, fieldSpec.title, 'title');
-        assignSingleField(normalDoc, doc, fieldSpec.thumb, 'thumb');
-        normalDoc.subs = {};
+      var fieldDisplayName = function(funcFieldQuery) {
+        // to Solr this is sent as foo:$foo, we just want to display "foo"
+        return funcFieldQuery.split(':')[0];
+      };
+
+      var assignSubs = function(normalDoc, doc, fieldSpec) {
         if (fieldSpec.subs === '*') {
           angular.forEach(doc, function(value, fieldName) {
             if (typeof(value) !== 'function') {
@@ -50,7 +51,23 @@ angular.module('o19s.splainer-search')
               normalDoc.subs[subFieldName] = '' + doc[subFieldName];
             }
           });
+          angular.forEach(fieldSpec.functions, function(functionField) {
+            // for foo:$foo, look for foo
+            var dispName = fieldDisplayName(functionField);
+            if (doc.hasOwnProperty(dispName)) {
+              normalDoc.subs[dispName] = '' + doc[dispName];
+            }
+
+          });
         }
+      };
+
+      var assignFields = function(normalDoc, doc, fieldSpec) {
+        assignSingleField(normalDoc, doc, fieldSpec.id, 'id');
+        assignSingleField(normalDoc, doc, fieldSpec.title, 'title');
+        assignSingleField(normalDoc, doc, fieldSpec.thumb, 'thumb');
+        normalDoc.subs = {};
+        assignSubs(normalDoc, doc, fieldSpec);
       };
 
       // A document within a query

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -485,6 +485,14 @@ angular.module('o19s.splainer-search')
   .service('fieldSpecSvc', [
     function fieldSpecSvc() {
       var addFieldOfType = function(fieldSpec, fieldType, fieldName) {
+        if (fieldType === 'function') {
+          // a function query function:foo is really foo:$foo
+          fieldType = 'sub';
+          if (fieldName.startsWith('$')) {
+            fieldName = fieldName.slice(1);
+          }
+          fieldName = fieldName + ':$' + fieldName;
+        }
         if (fieldType === 'sub') {
           if (!fieldSpec.hasOwnProperty('subs')) {
             fieldSpec.subs = [];
@@ -502,6 +510,13 @@ angular.module('o19s.splainer-search')
         fieldSpec.fields.push(fieldName);
       };
 
+      var normalizeFieldTypeAliases = function(fieldType) {
+        if (fieldType === 'func' || fieldType === 'f') {
+          return 'function';
+        }
+        return fieldType;
+      };
+
       // Populate field spec from a field spec string
       var populateFieldSpec = function(fieldSpec, fieldSpecStr) {
         var fieldSpecs = fieldSpecStr.split('+').join(' ').split(/[\s,]+/);
@@ -510,7 +525,7 @@ angular.module('o19s.splainer-search')
           var fieldType = null;
           var fieldName = null;
           if (typeAndField.length === 2) {
-            fieldType = typeAndField[0];
+            fieldType = normalizeFieldTypeAliases(typeAndField[0]);
             fieldName = typeAndField[1];
           }
           else if (typeAndField.length === 1) {

--- a/test/spec/fieldSpecSvc.js
+++ b/test/spec/fieldSpecSvc.js
@@ -132,4 +132,55 @@ describe('Service: fieldSpecSvc', function () {
     expect(fieldSpec.fieldList()).toEqual('*');
   });
 
+  it('preserves certain computed fields', function() {
+    var fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,function:someFunctionQuery');
+    expect(fieldSpec.subs).toContain('text');
+    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.id).toEqual('id');
+    expect(fieldSpec.title).toEqual('catch_line');
+
+    var fieldList = fieldSpec.fieldList();
+    expect(fieldList).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldList).toContain('text');
+    expect(fieldList).toContain('catch_line');
+  });
+
+  it('tolerates $ in function field name', function() {
+    var fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,function:$someFunctionQuery');
+    expect(fieldSpec.subs).toContain('text');
+    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.id).toEqual('id');
+    expect(fieldSpec.title).toEqual('catch_line');
+
+    var fieldList = fieldSpec.fieldList();
+    expect(fieldList).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldList).toContain('text');
+    expect(fieldList).toContain('catch_line');
+  });
+
+  it('respects function aliases', function() {
+    var fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,func:someFunctionQuery');
+    expect(fieldSpec.subs).toContain('text');
+    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.id).toEqual('id');
+    expect(fieldSpec.title).toEqual('catch_line');
+
+    var fieldList = fieldSpec.fieldList();
+    expect(fieldList).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldList).toContain('text');
+    expect(fieldList).toContain('catch_line');
+
+    fieldSpec = fieldList = undefined;
+    fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,f:someFunctionQuery');
+    expect(fieldSpec.subs).toContain('text');
+    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.id).toEqual('id');
+    expect(fieldSpec.title).toEqual('catch_line');
+
+    fieldList = fieldSpec.fieldList();
+    expect(fieldList).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldList).toContain('text');
+    expect(fieldList).toContain('catch_line');
+  });
+
 });

--- a/test/spec/fieldSpecSvc.js
+++ b/test/spec/fieldSpecSvc.js
@@ -135,7 +135,7 @@ describe('Service: fieldSpecSvc', function () {
   it('preserves certain computed fields', function() {
     var fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,function:someFunctionQuery');
     expect(fieldSpec.subs).toContain('text');
-    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.functions).toContain('someFunctionQuery:$someFunctionQuery');
     expect(fieldSpec.id).toEqual('id');
     expect(fieldSpec.title).toEqual('catch_line');
 
@@ -148,7 +148,7 @@ describe('Service: fieldSpecSvc', function () {
   it('tolerates $ in function field name', function() {
     var fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,function:$someFunctionQuery');
     expect(fieldSpec.subs).toContain('text');
-    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.functions).toContain('someFunctionQuery:$someFunctionQuery');
     expect(fieldSpec.id).toEqual('id');
     expect(fieldSpec.title).toEqual('catch_line');
 
@@ -161,7 +161,7 @@ describe('Service: fieldSpecSvc', function () {
   it('respects function aliases', function() {
     var fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,func:someFunctionQuery');
     expect(fieldSpec.subs).toContain('text');
-    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.functions).toContain('someFunctionQuery:$someFunctionQuery');
     expect(fieldSpec.id).toEqual('id');
     expect(fieldSpec.title).toEqual('catch_line');
 
@@ -173,7 +173,7 @@ describe('Service: fieldSpecSvc', function () {
     fieldSpec = fieldList = undefined;
     fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,f:someFunctionQuery');
     expect(fieldSpec.subs).toContain('text');
-    expect(fieldSpec.subs).toContain('someFunctionQuery:$someFunctionQuery');
+    expect(fieldSpec.functions).toContain('someFunctionQuery:$someFunctionQuery');
     expect(fieldSpec.id).toEqual('id');
     expect(fieldSpec.title).toEqual('catch_line');
 

--- a/test/spec/normalDocSvc.js
+++ b/test/spec/normalDocSvc.js
@@ -315,6 +315,7 @@ describe('Service: normalDocsSvc', function () {
                  'title_field': 'a title',
                  'sub1': 'sub1_val',
                  'sub2': 'sub2_val',
+                 'fn': 2.0,
                  source: function() {
                    return this;
                  },
@@ -333,18 +334,36 @@ describe('Service: normalDocsSvc', function () {
     it('captures sub values no highlights', function() {
       var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: '*'};
       var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
-      expect(Object.keys(normalDoc.subs).length).toEqual(2);
+      expect(Object.keys(normalDoc.subs).length).toEqual(3);
       expect(normalDoc.subs.sub1).toEqual('sub1_val');
       expect(normalDoc.subs.sub2).toEqual('sub2_val');
+    });
+
+    it('captures function values as subs', function() {
+      var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: ['sub2'], functions: ['fn:$fn']};
+      var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
+      expect(Object.keys(normalDoc.subs).length).toEqual(2);
+      expect(normalDoc.subs.sub2).toEqual('sub2_val');
+      expect(normalDoc.subs.fn).toEqual('2');
+    });
+
+    it('captures function values with wildcard subs', function() {
+      var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: '*', functions: ['fn:$fn']};
+      var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
+      expect(Object.keys(normalDoc.subs).length).toEqual(3);
+      expect(normalDoc.subs.sub1).toEqual('sub1_val');
+      expect(normalDoc.subs.sub2).toEqual('sub2_val');
+      expect(normalDoc.subs.fn).toEqual('2');
     });
 
     it('captures sub values w/ highlight', function() {
       var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: '*'};
       availableHighlights.sub1 = 'sub1_hl';
       var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
-      expect(Object.keys(normalDoc.subs).length).toEqual(2);
+      expect(Object.keys(normalDoc.subs).length).toEqual(3);
       expect(normalDoc.subs.sub1).toEqual('sub1_val');
       expect(normalDoc.subs.sub2).toEqual('sub2_val');
+      expect(normalDoc.subs.fn).toEqual('2');
 
       expect(normalDoc.subSnippets('<b>', '</b>').sub1).toEqual('<b>sub1_hl</b>');
       expect(normalDoc.subSnippets('<b>', '</b>').sub2).toEqual('sub2_val');


### PR DESCRIPTION
## Changelog
- Modify fieldSpecSvc to accept fields of role "function"
- fieldSpecSvc returns these to the fieldList of a syntax amiable to Solr function queries, ie `function:foo` -> `foo:$foo`
- normalDocsSvc consumes function responses in Solr docs and normalizes them into the "subs" array
- Associated tests
## Acceptance Criteria
- Specify some complex query in Splainer/Quepid like

```
q=text:law&
someFunctionQuery=tf('text','law')
```
- Tell Splainer/Quepid to display the result of someFunctionQuery in the field list
  `catch_line text function:someFunctionQuery`
- Confirm you see "someFunctionQuery" as a field in the displayed documents with a numerical value

![image](https://cloud.githubusercontent.com/assets/629060/12149757/7e7d1a76-b473-11e5-93de-6d8c21285e27.png)
### Allowable variations

We allow some variation in this syntax to account for common shortcuts or likely errors. The following should all be equivalent to the above syntax.

```
f:someFunctionQuery
func:someFunctionQuery
f:$someFunctionQuery
func:$someFunctionQuery
```

I allow the $ because Solr developers will often do this out of habit.
### What won't work

We don't currently support directly specifying a function query. For example, this in your field list won't work

```
func:tf('text','law')
```

Elasticsearch is also not supported.

This syntax should silently fail in these cases (nothing is displayed).
