### PR TITLE
Explain other

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,76 @@ searcher.search()
 });
 ```
 
+## Explain Other
+
+Let's say you have performed a search for `tacos` and you get a bunch of results, but the chef comes back to you and says:
+
+> Hey! My new creation "La Bomba" is not showing up, fix it!!!!
+
+So you are puzzled as to why it is not showing up, since it's clearly marked as a `taco` in the db. Wouldn't it be nice if `splainer-search` gave you some help?
+
+Don't worry, we've got your back :)
+
+### Solr
+
+So assuming you already have something like this:
+
+```js
+var options = {
+  fields:       ['id', 'title', 'price'],
+  url:          'http://localhost:8983/solr/select',
+  args:         { 'q': ['#$query##'] },
+  query:        'tacos',
+  config:       {},
+  searchEngine: 'solr'
+};
+var searcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine);
+
+searcher.search();
+```
+
+You would want to create a new searcher with the same options/context, and use the `explainOther()` function:
+
+```js
+var fieldSpec       = fieldSpecSvc.createFieldSpec(options.fields);
+var explainSearcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine); # same options as above
+
+ # assuming that we know "El Bomba" has id 63148
+explainSearcher.explainOther('id:63148', fieldSpec);
+```
+
+The `explainOther()` function returns the same promise as the `search()` function so you can you retrieve the results in the same way.
+
+### ElasticSearch
+
+In ES, the `explainOther()` function behaves the same way, except that it does not need a `fieldSpec` param to be passed in.
+
+```js
+var options = {
+  fields:       ['id', 'title', 'price'],
+  url:          'http://localhost:9200/tacos/_search',
+  args:         {
+    'query': {
+      'match': {
+        'title': '#$query##'
+      }
+    }
+  },
+  query:        'tacos',
+  config:       {},
+  searchEngine: 'es'
+};
+var searcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine);
+
+searcher.search();
+
+var explainSearcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine); # same options as above
+
+ # assuming that we know "El Bomba" has id 63148
+explainSearcher.explainOther('id:63148');
+```
+
+The `explainOther()` function returns the same promise as the `search()` function so you can you retrieve the results in the same way.
 
 ## Normalizing docs with normalDocs/fieldSpec
 

--- a/factories/docFactory.js
+++ b/factories/docFactory.js
@@ -16,7 +16,7 @@
 
       self.groupedBy  = groupedBy;
       self.group      = group;
-      self.options      = options;
+      self.options    = options;
 
       function groupedBy () {
         if (opts.groupedBy === undefined) {

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -97,6 +97,7 @@
         url:        self.url,
         args:       nextArgs,
         queryText:  self.queryText,
+        type:       self.type,
       };
 
       var nextSearcher = new Searcher(options);
@@ -202,7 +203,8 @@
         url:        self.url,
         args:       self.args,
         queryText:  otherQuery,
-        config:     { apiMethod: 'get' }
+        config:     { apiMethod: 'get' },
+        type:       self.type,
       };
 
       var otherSearcher = new Searcher(otherSearcherOptions);

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -13,7 +13,6 @@
       'esUrlSvc',
       'SearcherFactory',
       'transportSvc',
-      'normalDocsSvc',
       EsSearcherFactory
     ]);
 
@@ -23,7 +22,7 @@
     activeQueries,
     esSearcherPreprocessorSvc, esUrlSvc,
     SearcherFactory,
-    transportSvc, normalDocsSvc
+    transportSvc
   ) {
 
     var Searcher = function(options) {
@@ -194,7 +193,7 @@
       });
     } // end of search()
 
-    function explainOther (otherQuery, fieldSpec) {
+    function explainOther (otherQuery) {
       /*jslint validthis:true*/
       var self = this;
 
@@ -219,8 +218,7 @@
           angular.forEach(otherSearcher.docs, function(doc) {
             var promise = self.explain(doc)
               .then(function(parsedDoc) {
-                var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, parsedDoc);
-                docs.push(normalDoc);
+                docs.push(parsedDoc);
               });
 
             promises.push(promise);

--- a/factories/httpGetTransportFactory.js
+++ b/factories/httpGetTransportFactory.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/*jslint latedef:false*/
+
+(function() {
+  angular.module('o19s.splainer-search')
+    .factory('HttpGetTransportFactory', [
+      'TransportFactory',
+      '$http',
+      HttpGetTransportFactory
+    ]);
+
+  function HttpGetTransportFactory(TransportFactory, $http) {
+    var Transport = function(options) {
+      TransportFactory.call(this, options);
+    };
+
+    Transport.prototype = Object.create(TransportFactory.prototype);
+    Transport.prototype.constructor = Transport;
+
+    Transport.prototype.query = query;
+
+    function query(url, payload, headers) {
+      var requestConfig = {headers: headers};
+      return $http.get(url, requestConfig);
+    }
+
+    return Transport;
+  }
+})();

--- a/factories/searcherFactory.js
+++ b/factories/searcherFactory.js
@@ -15,6 +15,7 @@
       self.args               = options.args;
       self.queryText          = options.queryText;
       self.config             = options.config;
+      self.type               = options.type;
 
       self.docs               = [];
       self.grouped            = {};

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -11,7 +11,6 @@
       'activeQueries',
       'defaultSolrConfig',
       'solrSearcherPreprocessorSvc',
-      'normalDocsSvc',
       SolrSearcherFactory
     ]);
 
@@ -19,7 +18,7 @@
     $http,
     SolrDocFactory, SearcherFactory,
     activeQueries, defaultSolrConfig,
-    solrSearcherPreprocessorSvc, normalDocsSvc
+    solrSearcherPreprocessorSvc
   ) {
     var Searcher = function(options) {
       SearcherFactory.call(this, options, solrSearcherPreprocessorSvc);
@@ -182,28 +181,6 @@
       /*jslint validthis:true*/
       var self = this;
 
-      var getOverridingExplain = function(doc, fieldSpec, overridingExplains) {
-        var idFieldName = fieldSpec.id;
-        var id = doc[idFieldName];
-
-        if (id && overridingExplains && overridingExplains.hasOwnProperty(id)) {
-          return overridingExplains[id];
-        }
-        return null;
-      };
-
-      var docsWithExplainOther = function(newDocs, fieldSpec, othersExplained) {
-        var docs = [];
-
-        angular.forEach(newDocs, function(doc) {
-          var overridingExplain = getOverridingExplain(doc, fieldSpec, othersExplained);
-          var normalDoc         = normalDocsSvc.createNormalDoc(fieldSpec, doc, overridingExplain);
-          docs.push(normalDoc);
-        });
-
-        return docs;
-      };
-
       // var args = angular.copy(self.args);
       self.args.explainOther = [otherQuery];
       solrSearcherPreprocessorSvc.prepare(self);
@@ -229,7 +206,7 @@
           return otherSearcher.search()
             .then(function() {
               self.numFound        = otherSearcher.numFound;
-              self.docs            = docsWithExplainOther(otherSearcher.docs, fieldSpec, self.othersExplained);
+              self.docs            = otherSearcher.docs;
             });
         });
     }

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -204,23 +204,12 @@
         return docs;
       };
 
-      var args = angular.copy(self.args);
-      args.explainOther = [otherQuery];
+      // var args = angular.copy(self.args);
+      self.args.explainOther = [otherQuery];
+      solrSearcherPreprocessorSvc.prepare(self);
 
-      var options = {
-        fieldList:  self.fieldList,
-        url:        self.url,
-        args:       args,
-        queryText:  self.queryText,
-        config:     self.config
-      };
-
-      var searcher = new Searcher(options);
-
-      return searcher.search()
+      return self.search()
         .then(function() {
-          var othersExplained = searcher.othersExplained;
-
           var solrParams = {
             qf:   [fieldSpec.title + ' ' + fieldSpec.id],
             rows: [5],
@@ -239,10 +228,8 @@
 
           return otherSearcher.search()
             .then(function() {
-              return {
-                numFound: otherSearcher.numFound,
-                docs:     docsWithExplainOther(otherSearcher.docs, fieldSpec, othersExplained)
-              };
+              self.numFound        = otherSearcher.numFound;
+              self.docs            = docsWithExplainOther(otherSearcher.docs, fieldSpec, self.othersExplained);
             });
         });
     }

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -85,7 +85,8 @@
         url:        self.url,
         args:       nextArgs,
         queryText:  self.queryText,
-        config:     pageConfig
+        config:     pageConfig,
+        type:       self.type
       };
 
       var nextSearcher = new Searcher(options);
@@ -198,7 +199,8 @@
             url:        self.url,
             args:       solrParams,
             queryText:  otherQuery,
-            config:     {}
+            config:     {},
+            type:       self.type,
           };
 
           var otherSearcher = new Searcher(otherSearcherOptions);

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -186,6 +186,8 @@
       self.args.explainOther = [otherQuery];
       solrSearcherPreprocessorSvc.prepare(self);
 
+      // TODO: revisit why we perform the first search, doesn't seem to have
+      // any use!
       return self.search()
         .then(function() {
           var solrParams = {

--- a/services/esExplainExtractorSvc.js
+++ b/services/esExplainExtractorSvc.js
@@ -1,0 +1,23 @@
+'use strict';
+
+angular.module('o19s.splainer-search')
+  .service('esExplainExtractorSvc', [
+    'normalDocsSvc',
+    function esExplainExtractorSvc(normalDocsSvc) {
+      var self = this;
+
+      // Functions
+      self.docsWithExplainOther = docsWithExplainOther;
+
+      function docsWithExplainOther(docs, fieldSpec) {
+        var parsedDocs = [];
+
+        angular.forEach(docs, function(doc) {
+          var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, doc);
+          parsedDocs.push(normalDoc);
+        });
+
+        return parsedDocs;
+      }
+    }
+  ]);

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -3,7 +3,8 @@
 angular.module('o19s.splainer-search')
   .service('esSearcherPreprocessorSvc', [
     'queryTemplateSvc',
-    function esSearcherPreprocessorSvc(queryTemplateSvc) {
+    'defaultESConfig',
+    function esSearcherPreprocessorSvc(queryTemplateSvc, defaultESConfig) {
       var self      = this;
       self.prepare  = prepare;
 
@@ -43,7 +44,7 @@ angular.module('o19s.splainer-search')
         }
       };
 
-      function prepare (searcher) {
+      var preparePostRequest = function (searcher) {
         var pagerArgs       = angular.copy(searcher.args.pager);
         searcher.pagerArgs  = pagerArgs;
         delete searcher.args.pager;
@@ -61,6 +62,26 @@ angular.module('o19s.splainer-search')
         }
 
         searcher.queryDsl   = queryDsl;
+      };
+
+      var prepareGetRequest = function (searcher) {
+        searcher.url = searcher.url + '?q=' + searcher.queryText;
+      };
+
+      function prepare (searcher) {
+        if (searcher.config === undefined) {
+          searcher.config = defaultESConfig;
+        } else {
+          // make sure config params that weren't passed through are set from
+          // the default config object.
+          searcher.config = angular.merge({}, defaultESConfig, searcher.config);
+        }
+
+        if ( searcher.config.apiMethod === 'post') {
+          preparePostRequest(searcher);
+        } else if ( searcher.config.apiMethod === 'get') {
+          prepareGetRequest(searcher);
+        }
       }
     }
   ]);

--- a/services/searchSvc.js
+++ b/services/searchSvc.js
@@ -47,7 +47,8 @@ angular.module('o19s.splainer-search')
           url:            url,
           args:           args,
           queryText:      queryText,
-          config:         config
+          config:         config,
+          type:           searchEngine
         };
 
         var searcher;

--- a/services/solrExplainExtractorSvc.js
+++ b/services/solrExplainExtractorSvc.js
@@ -1,0 +1,37 @@
+'use strict';
+
+angular.module('o19s.splainer-search')
+  .service('solrExplainExtractorSvc', [
+    'normalDocsSvc',
+    function solrExplainExtractorSvc(normalDocsSvc) {
+      var self = this;
+
+      // Functions
+      self.getOverridingExplain   = getOverridingExplain;
+      self.docsWithExplainOther   = docsWithExplainOther;
+
+      function getOverridingExplain(doc, fieldSpec, explainData) {
+        var idFieldName = fieldSpec.id;
+        var id          = doc[idFieldName];
+
+        if (id && explainData && explainData.hasOwnProperty(id)) {
+          return explainData[id];
+        }
+
+        return null;
+      }
+
+      function docsWithExplainOther(docs, fieldSpec, explainData) {
+        var parsedDocs = [];
+
+        angular.forEach(docs, function(doc) {
+          var overridingExplain = self.getOverridingExplain(doc, fieldSpec, explainData);
+          var normalDoc         = normalDocsSvc.createNormalDoc(fieldSpec, doc, overridingExplain);
+
+          parsedDocs.push(normalDoc);
+        });
+
+        return parsedDocs;
+      }
+    }
+  ]);

--- a/services/transportSvc.js
+++ b/services/transportSvc.js
@@ -3,18 +3,30 @@
 angular.module('o19s.splainer-search')
   .service('transportSvc', [
     'HttpPostTransportFactory',
+    'HttpGetTransportFactory',
     'BulkTransportFactory',
-    function transportSvc(HttpPostTransportFactory, BulkTransportFactory) {
+    function transportSvc(
+      HttpPostTransportFactory,
+      HttpGetTransportFactory,
+      BulkTransportFactory
+    ) {
       var self = this;
+
+      // functions
       self.getTransport = getTransport;
-      var bulkTransport = new BulkTransportFactory({});
+
+      var bulkTransport     = new BulkTransportFactory({});
       var httpPostTransport = new HttpPostTransportFactory({});
+      var httpGetTransport  = new HttpGetTransportFactory({});
 
       function getTransport(options) {
-        if (options.searchApi === 'bulk') {
+        if (options.apiMethod === 'bulk') {
           return bulkTransport;
+        } else if (options.apiMethod === 'get') {
+          return httpGetTransport;
+        } else {
+          return httpPostTransport;
         }
-        return httpPostTransport;
       }
     }
   ]);

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2288,6 +2288,75 @@ angular.module('o19s.splainer-search')
       });
     }
 
+    function explainOther (otherQuery, fieldSpec) {
+      /*jslint validthis:true*/
+      var self = this;
+
+      var getOverridingExplain = function(doc, fieldSpec, overridingExplains) {
+        var idFieldName = fieldSpec.id;
+        var id = doc[idFieldName];
+
+        if (id && overridingExplains && overridingExplains.hasOwnProperty(id)) {
+          return overridingExplains[id];
+        }
+        return null;
+      };
+
+      var docsWithExplainOther = function(newDocs, fieldSpec, othersExplained) {
+        var docs = [];
+
+        angular.forEach(newDocs, function(doc) {
+          var overridingExplain = getOverridingExplain(doc, fieldSpec, othersExplained);
+          var normalDoc         = normalDocsSvc.createNormalDoc(fieldSpec, doc, overridingExplain);
+          docs.push(normalDoc);
+        });
+
+        return docs;
+      };
+
+      var args = angular.copy(self.args);
+      args.explainOther = [otherQuery];
+
+      var options = {
+        fieldList:  self.fieldList,
+        url:        self.url,
+        args:       args,
+        queryText:  self.queryText,
+        config:     self.config
+      };
+
+      var searcher = new Searcher(options);
+
+      return searcher.search()
+        .then(function() {
+          var othersExplained = searcher.othersExplained;
+
+          var solrParams = {
+            qf:   [fieldSpec.title + ' ' + fieldSpec.id],
+            rows: [5],
+            q:    [otherQuery]
+          };
+
+          var otherSearcherOptions = {
+            fieldList:  self.fieldList,
+            url:        self.url,
+            args:       solrParams,
+            queryText:  otherQuery,
+            config:     {}
+          };
+
+          var otherSearcher = new Searcher(otherSearcherOptions);
+
+          return otherSearcher.search()
+            .then(function() {
+              return {
+                numFound: otherSearcher.numFound,
+                docs:     docsWithExplainOther(otherSearcher.docs, fieldSpec, othersExplained)
+              };
+            });
+        });
+    }
+
     // Return factory object
     return Searcher;
   }
@@ -2730,14 +2799,20 @@ angular.module('o19s.splainer-search')
     .factory('SolrSearcherFactory', [
       '$http',
       'SolrDocFactory',
+      'SearcherFactory',
       'activeQueries',
       'defaultSolrConfig',
       'solrSearcherPreprocessorSvc',
-      'SearcherFactory',
+      'normalDocsSvc',
       SolrSearcherFactory
     ]);
 
-  function SolrSearcherFactory($http, SolrDocFactory, activeQueries, defaultSolrConfig, solrSearcherPreprocessorSvc, SearcherFactory) {
+  function SolrSearcherFactory(
+    $http,
+    SolrDocFactory, SearcherFactory,
+    activeQueries, defaultSolrConfig,
+    solrSearcherPreprocessorSvc, normalDocsSvc
+  ) {
     var Searcher = function(options) {
       SearcherFactory.call(this, options, solrSearcherPreprocessorSvc);
     };
@@ -2748,6 +2823,7 @@ angular.module('o19s.splainer-search')
     Searcher.prototype.addDocToGroup    = addDocToGroup;
     Searcher.prototype.pager            = pager;
     Searcher.prototype.search           = search;
+    Searcher.prototype.explainOther     = explainOther;
 
     function addDocToGroup (groupedBy, group, solrDoc) {
       /*jslint validthis:true*/

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2314,23 +2314,12 @@ angular.module('o19s.splainer-search')
         return docs;
       };
 
-      var args = angular.copy(self.args);
-      args.explainOther = [otherQuery];
+      // var args = angular.copy(self.args);
+      self.args.explainOther = [otherQuery];
+      solrSearcherPreprocessorSvc.prepare(self);
 
-      var options = {
-        fieldList:  self.fieldList,
-        url:        self.url,
-        args:       args,
-        queryText:  self.queryText,
-        config:     self.config
-      };
-
-      var searcher = new Searcher(options);
-
-      return searcher.search()
+      return self.search()
         .then(function() {
-          var othersExplained = searcher.othersExplained;
-
           var solrParams = {
             qf:   [fieldSpec.title + ' ' + fieldSpec.id],
             rows: [5],
@@ -2349,10 +2338,8 @@ angular.module('o19s.splainer-search')
 
           return otherSearcher.search()
             .then(function() {
-              return {
-                numFound: otherSearcher.numFound,
-                docs:     docsWithExplainOther(otherSearcher.docs, fieldSpec, othersExplained)
-              };
+              self.numFound        = otherSearcher.numFound;
+              self.docs            = docsWithExplainOther(otherSearcher.docs, fieldSpec, self.othersExplained);
             });
         });
     }

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2333,6 +2333,7 @@ angular.module('o19s.splainer-search')
         url:        self.url,
         args:       nextArgs,
         queryText:  self.queryText,
+        type:       self.type,
       };
 
       var nextSearcher = new Searcher(options);
@@ -2438,7 +2439,8 @@ angular.module('o19s.splainer-search')
         url:        self.url,
         args:       self.args,
         queryText:  otherQuery,
-        config:     { apiMethod: 'get' }
+        config:     { apiMethod: 'get' },
+        type:       self.type,
       };
 
       var otherSearcher = new Searcher(otherSearcherOptions);
@@ -3048,7 +3050,8 @@ angular.module('o19s.splainer-search')
         url:        self.url,
         args:       nextArgs,
         queryText:  self.queryText,
-        config:     pageConfig
+        config:     pageConfig,
+        type:       self.type
       };
 
       var nextSearcher = new Searcher(options);
@@ -3161,7 +3164,8 @@ angular.module('o19s.splainer-search')
             url:        self.url,
             args:       solrParams,
             queryText:  otherQuery,
-            config:     {}
+            config:     {},
+            type:       self.type,
           };
 
           var otherSearcher = new Searcher(otherSearcherOptions);

--- a/test/spec/esExplainExtractorSvc.js
+++ b/test/spec/esExplainExtractorSvc.js
@@ -1,0 +1,83 @@
+'use strict';
+
+describe('Service: ES Explain Extractor', function () {
+  // load the service's module
+  beforeEach(module('o19s.splainer-search'));
+
+  var esExplainExtractorSvc, fieldSpecSvc, mockFieldSpec, EsDocFactory;
+
+  beforeEach(inject(function (_esExplainExtractorSvc_, _fieldSpecSvc_, _EsDocFactory_) {
+    esExplainExtractorSvc   = _esExplainExtractorSvc_;
+    fieldSpecSvc            = _fieldSpecSvc_;
+    EsDocFactory            = _EsDocFactory_;
+    mockFieldSpec           = fieldSpecSvc.createFieldSpec('field field1');
+  }));
+
+  describe('extracts explain info for docs', function() {
+    var basicExplain1 = {
+      value: 1.5,
+      description: 'weight(text:law in 1234)',
+    };
+    var basicExplain2 = {
+      value: 0.5,
+      description: 'weight(text:order in 1234)',
+    };
+
+    var sumExplain = {
+      matched:      true,
+      explanation:  {
+        value:        1.5,
+        description:  'weight(_all:law in 1234)',
+        details:      [basicExplain1, basicExplain2]
+      }
+    };
+
+    var expectedDocs = [
+      {
+        '_index': 'statedecoded',
+        '_type':  'law',
+        '_id':    'l_1',
+        '_score': 5.0,
+        'fields': {
+          'field':  ['1--field value'],
+          'field1': ['1--field1 value']
+        },
+      },
+      {
+        '_index': 'statedecoded',
+        '_type':  'law',
+        '_id':    'l_1',
+        '_score': 3.0,
+        'fields': {
+          'field':  ['2--field value'],
+          'field1': ['2--field1 value']
+        }
+      }
+    ];
+
+    it('passes two solr queries one explains the other', function() {
+      var explDict  = {
+        match:        sumExplain.matched,
+        explanation:  sumExplain.explanation,
+        description:  sumExplain.explanation.description,
+        value:        sumExplain.explanation.value,
+      };
+
+      var options = {
+        fieldList:  mockFieldSpec,
+        url:        'http://example.com',
+        explDict:   explDict,
+      };
+
+      var esDocs = [];
+      angular.forEach(expectedDocs, function(doc){
+        esDocs.push(new EsDocFactory(doc, options));
+      });
+
+      var docs = esExplainExtractorSvc.docsWithExplainOther(esDocs, mockFieldSpec);
+
+      expect(docs.length).toBe(2);
+      expect(Object.keys(docs[0].hotMatches().vecObj).length).toBe(1);
+    });
+  });
+});

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -862,18 +862,6 @@ describe('Service: searchSvc: ElasticSearch', function() {
         .then(function() {
           expect(searcher.numFound).toBe(2);
           expect(searcher.docs.length).toBe(2);
-
-          expect(Object.keys(searcher.docs[0].hotMatches().vecObj).length).toBe(1);
-
-          // console.log('searcher.docs[0].explain(): ', searcher.docs[0].explain());
-          // console.log('sumExplain: ', sumExplain);
-          // expect(searcher.docs[0].explain().match).toEqual(sumExplain.matched);
-          // expect(
-          //   angular.equals( searcher.docs[0].explain().description, sumExplain.description )
-          // ).toBe(true);
-          // expect(
-          //   angular.equals( searcher.docs[0].explain().explanation, sumExplain.explanation )
-          // ).toBe(true);
         });
 
       $httpBackend.flush();

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -97,6 +97,27 @@ describe('Service: esUrlSvc', function () {
     });
   });
 
+  describe('build doc explain URL', function() {
+    var url = 'http://localhost:9200/tmdb/_search';
+
+    var doc = {
+      _index: 'tmdb',
+      _type:  'movies',
+      _id:    '1'
+    };
+
+    var uri = null;
+    beforeEach( function () {
+      uri = esUrlSvc.parseUrl(url);
+    });
+
+    it('builds a proper doc explain URL from the doc info', function() {
+      var docUrl = esUrlSvc.buildExplainUrl(uri, doc);
+
+      expect(docUrl).toBe('http://localhost:9200/tmdb/movies/1/_explain');
+    });
+  });
+
   describe('build URL', function() {
     var url = 'http://localhost:9200/tmdb/_search';
 

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -64,15 +64,15 @@ describe('Service: esUrlSvc', function () {
     it('understands when bulk endpoint used', function() {
       var url = 'http://es.quepid.com/tmdb/_search';
       var uri = esUrlSvc.parseUrl(url);
-      expect(uri.searchApi).toBe('post');
+      expect(esUrlSvc.isBulkCall(uri)).toBe(false);
 
       url = 'http://es.quepid.com/tmdb/_msearch';
       uri = esUrlSvc.parseUrl(url);
-      expect(uri.searchApi).toBe('bulk');
+      expect(esUrlSvc.isBulkCall(uri)).toBe(true);
 
       url = 'http://es.quepid.com/tmdb/_msearch/';
       uri = esUrlSvc.parseUrl(url);
-      expect(uri.searchApi).toBe('bulk');
+      expect(esUrlSvc.isBulkCall(uri)).toBe(true);
     });
   });
 

--- a/test/spec/solrExplainExtractorSvc.js
+++ b/test/spec/solrExplainExtractorSvc.js
@@ -1,0 +1,114 @@
+'use strict';
+
+describe('Service: Solr Explain Extractor', function () {
+  // load the service's module
+  beforeEach(module('o19s.splainer-search'));
+
+  var solrExplainExtractorSvc, fieldSpecSvc, mockFieldSpec, SolrDocFactory;
+
+  beforeEach(inject(function (_solrExplainExtractorSvc_, _fieldSpecSvc_, _SolrDocFactory_) {
+    solrExplainExtractorSvc = _solrExplainExtractorSvc_;
+    fieldSpecSvc            = _fieldSpecSvc_;
+    SolrDocFactory          = _SolrDocFactory_;
+    mockFieldSpec           = fieldSpecSvc.createFieldSpec('field field1');
+  }));
+
+  describe('extracts explain info for docs', function() {
+    var mockSolrResp = {
+      response: {
+        numFound: 2,
+        docs : [
+          {id: 'doc1', title: 'title1'},
+          {id: 'doc2', title: 'title2'}
+        ]
+      }
+    };
+
+    var explOtherDoc1 = {
+      match:       false,
+      value:       0.0,
+      description: 'no matching term'
+    };
+
+    var explOtherDoc2 = {
+      match:        true,
+      value:        3.3733945,
+      description:  'weight(catch_line:law in 4487) [DefaultSimilarity], result of:',
+      details: [
+        {
+          match:        true,
+          value:        3.3733945,
+          description:  'fieldWeight in 4487, product of:',
+          details :[
+            {
+              match:        true,
+              value:        1.0,
+              description:  'tf(freq=1.0), with freq of:',
+              details:[
+                {
+                  match:        true,
+                  value:        1.0,
+                  description:  'termFreq=1.0'
+                }
+              ]
+            },
+            {
+              match:        true,
+              value:        5.3974314,
+              description:  'idf(docFreq=247, maxDocs=20148)'
+            },
+            {
+              match:        true,
+              value:        0.625,
+              description:  'fieldNorm(doc=4487)'
+            }
+          ]
+        }
+      ]
+    };
+
+    var mockSolrExplOtherResp = {
+      response: {
+        numFound: 2,
+        docs : [
+          {id: 'not_doc1', title: 'title1'},
+          {id: 'not_doc2', title: 'title2'}
+        ]
+      },
+      debug: {
+        explainOther: {
+          'doc1': explOtherDoc1,
+          'doc2': explOtherDoc2
+        }
+      }
+    };
+
+    it('passes two solr queries one explains the other', function() {
+      var options = {
+        groupedBy:          '',
+        group:              '',
+        fieldList:          mockFieldSpec,
+        url:                'http://example.com',
+        explDict:           explOtherDoc1,
+        hlDict:             {},
+        highlightingPre:    "foo",
+        highlightingPost:   "/foo"
+      };
+
+      var solrDocs = [];
+      angular.forEach(mockSolrResp.response.docs, function(doc){
+        solrDocs.push(new SolrDocFactory(doc, options));
+      });
+
+      var docs = solrExplainExtractorSvc.docsWithExplainOther(solrDocs, mockFieldSpec, mockSolrExplOtherResp.debug.explainOther);
+
+      expect(docs.length).toBe(2);
+      expect(Object.keys(docs[0].hotMatches().vecObj).length).toBe(1);
+      expect(Object.keys(docs[0].hotMatches().vecObj)).toContain('no matching term');
+      expect(docs[0].hotMatches().vecObj['no matching term']).toBe(0);
+      expect(docs[0].score()).toBe(0);
+      expect(Object.keys(docs[1].hotMatches().vecObj).length).toBe(1);
+      expect(docs[1].score()).toBe(3.3733945);
+    });
+  });
+});

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -255,7 +255,6 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
       expect(called).toBe(1);
     });
-
   });
 
   describe('explain info ', function() {
@@ -652,7 +651,6 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
     });
   });
-
 
   describe('group-by', function() {
     var groupedSolrResp = { responseHeader:{
@@ -1141,6 +1139,141 @@ describe('Service: searchSvc: Solr', function () {
       // done
       nextSearcher = nextSearcher.pager();
       expect(nextSearcher).toBe(null);
+    });
+  });
+
+  describe('explain other', function() {
+    var mockSolrResp = {
+      response: {
+        numFound: 2,
+        docs : [
+          {id: 'doc1', title: 'title1'},
+          {id: 'doc2', title: 'title2'}
+        ]
+      }
+    };
+
+    var explOtherDoc1 = {
+      match:       false,
+      value:       0.0,
+      description: 'no matching term'
+    };
+
+    var explOtherDoc2 = {
+      match:        true,
+      value:        3.3733945,
+      description:  'weight(catch_line:law in 4487) [DefaultSimilarity], result of:',
+      details: [
+        {
+          match:        true,
+          value:        3.3733945,
+          description:  'fieldWeight in 4487, product of:',
+          details :[
+            {
+              match:        true,
+              value:        1.0,
+              description:  'tf(freq=1.0), with freq of:',
+              details:[
+                {
+                  match:        true,
+                  value:        1.0,
+                  description:  'termFreq=1.0'
+                }
+              ]
+            },
+            {
+              match:        true,
+              value:        5.3974314,
+              description:  'idf(docFreq=247, maxDocs=20148)'
+            },
+            {
+              match:        true,
+              value:        0.625,
+              description:  'fieldNorm(doc=4487)'
+            }
+          ]
+        }
+      ]
+    };
+
+    var mockSolrExplOtherResp = {
+      response: {
+        numFound: 2,
+        docs : [
+          {id: 'not_doc1', title: 'title1'},
+          {id: 'not_doc2', title: 'title2'}
+        ]
+      },
+      debug: {
+        explainOther: {
+          'doc1': explOtherDoc1,
+          'doc2': explOtherDoc2
+        }
+      }
+    };
+
+    it('passes two solr queries one explains the other', function() {
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList(),
+        mockSolrUrl,
+        mockSolrParams,
+        mockQueryText
+      );
+
+      var expectedParams = {
+        q: ['title:doc1']
+      };
+
+      var expectedExplOtherParams = {
+        explainOther: ['title:doc1']
+      };
+
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedExplOtherParams))
+        .respond(200, mockSolrExplOtherResp);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+        .respond(200, mockSolrResp);
+
+      var results = null;
+      searcher.explainOther('title:doc1', mockFieldSpec)
+        .then(function(response) {
+          results = response;
+        });
+
+      $httpBackend.flush();
+
+      expect(results.docs.length).toBe(2);
+      expect(Object.keys(results.docs[0].hotMatches().vecObj).length).toBe(1);
+      expect(Object.keys(results.docs[0].hotMatches().vecObj)).toContain('no matching term');
+      expect(results.docs[0].hotMatches().vecObj['no matching term']).toBe(0);
+      expect(results.docs[0].score()).toBe(0);
+      expect(Object.keys(results.docs[1].hotMatches().vecObj).length).toBe(1);
+      expect(results.docs[1].score()).toBe(3.3733945);
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
+    it('does not throw an error if both queries are empty', function () {
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList(),
+        mockSolrUrl,
+        mockSolrParams,
+        ''
+      );
+
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl))
+        .respond(200, mockSolrExplOtherResp);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl))
+        .respond(200, mockSolrResp);
+
+      var results = null;
+      searcher.explainOther('', mockFieldSpec)
+        .then(function(response) {
+          results = response;
+        });
+
+
+      $httpBackend.flush();
+      expect(results.docs.length).toBe(2);
+      $httpBackend.verifyNoOutstandingExpectation();
     });
   });
 });

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -1233,21 +1233,17 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
         .respond(200, mockSolrResp);
 
-      var results = null;
-      searcher.explainOther('title:doc1', mockFieldSpec)
-        .then(function(response) {
-          results = response;
-        });
+      searcher.explainOther('title:doc1', mockFieldSpec);
 
       $httpBackend.flush();
 
-      expect(results.docs.length).toBe(2);
-      expect(Object.keys(results.docs[0].hotMatches().vecObj).length).toBe(1);
-      expect(Object.keys(results.docs[0].hotMatches().vecObj)).toContain('no matching term');
-      expect(results.docs[0].hotMatches().vecObj['no matching term']).toBe(0);
-      expect(results.docs[0].score()).toBe(0);
-      expect(Object.keys(results.docs[1].hotMatches().vecObj).length).toBe(1);
-      expect(results.docs[1].score()).toBe(3.3733945);
+      expect(searcher.docs.length).toBe(2);
+      expect(Object.keys(searcher.docs[0].hotMatches().vecObj).length).toBe(1);
+      expect(Object.keys(searcher.docs[0].hotMatches().vecObj)).toContain('no matching term');
+      expect(searcher.docs[0].hotMatches().vecObj['no matching term']).toBe(0);
+      expect(searcher.docs[0].score()).toBe(0);
+      expect(Object.keys(searcher.docs[1].hotMatches().vecObj).length).toBe(1);
+      expect(searcher.docs[1].score()).toBe(3.3733945);
       $httpBackend.verifyNoOutstandingExpectation();
     });
 
@@ -1264,15 +1260,10 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl))
         .respond(200, mockSolrResp);
 
-      var results = null;
-      searcher.explainOther('', mockFieldSpec)
-        .then(function(response) {
-          results = response;
-        });
-
+      searcher.explainOther('', mockFieldSpec);
 
       $httpBackend.flush();
-      expect(results.docs.length).toBe(2);
+      expect(searcher.docs.length).toBe(2);
       $httpBackend.verifyNoOutstandingExpectation();
     });
   });

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -1238,12 +1238,6 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.flush();
 
       expect(searcher.docs.length).toBe(2);
-      expect(Object.keys(searcher.docs[0].hotMatches().vecObj).length).toBe(1);
-      expect(Object.keys(searcher.docs[0].hotMatches().vecObj)).toContain('no matching term');
-      expect(searcher.docs[0].hotMatches().vecObj['no matching term']).toBe(0);
-      expect(searcher.docs[0].score()).toBe(0);
-      expect(Object.keys(searcher.docs[1].hotMatches().vecObj).length).toBe(1);
-      expect(searcher.docs[1].score()).toBe(3.3733945);
       $httpBackend.verifyNoOutstandingExpectation();
     });
 

--- a/values/defaultESConfig.js
+++ b/values/defaultESConfig.js
@@ -1,0 +1,10 @@
+'use strict';
+
+angular.module('o19s.splainer-search')
+  .value('defaultESConfig', {
+    sanitize:     true,
+    highlight:    true,
+    debug:        true,
+    escapeQuery:  true,
+    apiMethod:    'post'
+  });


### PR DESCRIPTION
# Changelog
- Refactors explain other functionality out of quepid and into splainer-search
- Adds ability to use the explain other functionality for ES as well as Solr
