### PR TITLE
Fixes issue with the highlighting when doing explain other.

### DIFF
--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -197,12 +197,14 @@
           };
 
           var otherSearcherOptions = {
-            fieldList:  self.fieldList,
-            url:        self.url,
-            args:       solrParams,
-            queryText:  otherQuery,
-            config:     {},
-            type:       self.type,
+            fieldList:          self.fieldList,
+            url:                self.url,
+            args:               solrParams,
+            queryText:          otherQuery,
+            config:             {},
+            type:               self.type,
+            HIGHLIGHTING_PRE:   self.HIGHLIGHTING_PRE,
+            HIGHLIGHTING_POST:  self.HIGHLIGHTING_POST,
           };
 
           var otherSearcher = new Searcher(otherSearcherOptions);

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -3151,6 +3151,8 @@ angular.module('o19s.splainer-search')
       self.args.explainOther = [otherQuery];
       solrSearcherPreprocessorSvc.prepare(self);
 
+      // TODO: revisit why we perform the first search, doesn't seem to have
+      // any use!
       return self.search()
         .then(function() {
           var solrParams = {
@@ -3160,12 +3162,14 @@ angular.module('o19s.splainer-search')
           };
 
           var otherSearcherOptions = {
-            fieldList:  self.fieldList,
-            url:        self.url,
-            args:       solrParams,
-            queryText:  otherQuery,
-            config:     {},
-            type:       self.type,
+            fieldList:          self.fieldList,
+            url:                self.url,
+            args:               solrParams,
+            queryText:          otherQuery,
+            config:             {},
+            type:               self.type,
+            HIGHLIGHTING_PRE:   self.HIGHLIGHTING_PRE,
+            HIGHLIGHTING_POST:  self.HIGHLIGHTING_POST,
           };
 
           var otherSearcher = new Searcher(otherSearcherOptions);

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -1241,6 +1241,38 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
     });
 
+    it('highlights explain other', function() {
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList(),
+        mockSolrUrl,
+        mockSolrParams,
+        mockQueryText
+      );
+
+      var expectedParams = {
+        q: ['title:doc1'],
+        hl: ['true'],
+        'hl.simple.pre': [searchSvc.HIGHLIGHTING_PRE],
+        'hl.simple.post': [searchSvc.HIGHLIGHTING_POST]
+      };
+
+      var expectedExplOtherParams = {
+        explainOther: ['title:doc1']
+      };
+
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedExplOtherParams))
+        .respond(200, mockSolrExplOtherResp);
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+        .respond(200, mockSolrResp);
+
+      searcher.explainOther('title:doc1', mockFieldSpec);
+
+      $httpBackend.flush();
+
+      expect(searcher.docs.length).toBe(2);
+      $httpBackend.verifyNoOutstandingExpectation();
+    });
+
     it('does not throw an error if both queries are empty', function () {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),


### PR DESCRIPTION
# Acceptance criteria
- When using the `splainer-search` explain other feature the UI should not mess up the text with a bunch of `<em>` all over
