### PR TITLE
Provides a consistent, useful error message between Solr & ES

### DIFF
--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -176,7 +176,7 @@
               errorMsg +=  '\n';
               errorMsg +=  'Enable CORS in elasticsearch.yml:\n';
               errorMsg += '\n';
-              errorMsg += 'http.cors.allow-origin: "/.*/"\n';
+              errorMsg += 'http.cors.allow-origin: "/https?:\\/\\/(.*?\\.)?(quepid\\.com|splainer\\.io)/"';
               errorMsg += 'http.cors.enabled: true\n';
             }
             msg.searchError = errorMsg;

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -179,8 +179,9 @@
               errorMsg += 'http.cors.allow-origin: "/.*/"\n';
               errorMsg += 'http.cors.enabled: true\n';
             }
+            msg.searchError = errorMsg;
           }
-          return errorMsg;
+          return msg;
       };
 
       // Build URL with params if any

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -11,6 +11,7 @@
       'activeQueries',
       'defaultSolrConfig',
       'solrSearcherPreprocessorSvc',
+      '$q',
       SolrSearcherFactory
     ]);
 
@@ -18,7 +19,7 @@
     $http,
     SolrDocFactory, SearcherFactory,
     activeQueries, defaultSolrConfig,
-    solrSearcherPreprocessorSvc
+    solrSearcherPreprocessorSvc, $q
   ) {
     var Searcher = function(options) {
       SearcherFactory.call(this, options, solrSearcherPreprocessorSvc);
@@ -131,7 +132,8 @@
       };
 
       activeQueries.count++;
-      return $http.jsonp(url).success(function(solrResp) {
+      return $http.jsonp(url).then(function success(resp) {
+        var solrResp = resp.data;
         activeQueries.count--;
 
         var explDict  = getExplData(solrResp);
@@ -172,9 +174,10 @@
             });
           });
         }
-      }).error(function() {
+      }, function error(msg) {
         activeQueries.count--;
         thisSearcher.inError = true;
+        $q.reject(msg);
       });
     }
 

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -174,10 +174,10 @@
             });
           });
         }
-      }, function error(msg) {
+      }, function error() {
         activeQueries.count--;
         thisSearcher.inError = true;
-        $q.reject(msg);
+        $q.reject();
       });
     }
 

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2412,11 +2412,12 @@ angular.module('o19s.splainer-search')
               errorMsg +=  '\n';
               errorMsg +=  'Enable CORS in elasticsearch.yml:\n';
               errorMsg += '\n';
-              errorMsg += 'http.cors.allow-origin: "/.*/"\n';
+              errorMsg += 'http.cors.allow-origin: "/https?:\\/\\/(.*?\\.)?(quepid\\.com|splainer\\.io)/"';
               errorMsg += 'http.cors.enabled: true\n';
             }
+            msg.searchError = errorMsg;
           }
-          return errorMsg;
+          return msg;
       };
 
       // Build URL with params if any
@@ -3131,53 +3132,58 @@ angular.module('o19s.splainer-search')
       };
 
       activeQueries.count++;
-      return $http.jsonp(url).then(function success(resp) {
-        var solrResp = resp.data;
-        activeQueries.count--;
+      return $q(function(resolve, reject) {
+          $http.jsonp(url).then(function success(resp) {
+          var solrResp = resp.data;
+          activeQueries.count--;
 
-        var explDict  = getExplData(solrResp);
-        var hlDict    = getHlData(solrResp);
-        thisSearcher.othersExplained = getOthersExplained(solrResp);
+          var explDict  = getExplData(solrResp);
+          var hlDict    = getHlData(solrResp);
+          thisSearcher.othersExplained = getOthersExplained(solrResp);
 
-        var parseSolrDoc = function(solrDoc, groupedBy, group) {
-          var options = {
-            groupedBy:          groupedBy,
-            group:              group,
-            fieldList:          self.fieldList,
-            url:                self.url,
-            explDict:           explDict,
-            hlDict:             hlDict,
-            highlightingPre:    self.HIGHLIGHTING_PRE,
-            highlightingPost:   self.HIGHLIGHTING_POST
+          var parseSolrDoc = function(solrDoc, groupedBy, group) {
+            var options = {
+              groupedBy:          groupedBy,
+              group:              group,
+              fieldList:          self.fieldList,
+              url:                self.url,
+              explDict:           explDict,
+              hlDict:             hlDict,
+              highlightingPre:    self.HIGHLIGHTING_PRE,
+              highlightingPost:   self.HIGHLIGHTING_POST
+            };
+
+            return new SolrDocFactory(solrDoc, options);
           };
 
-          return new SolrDocFactory(solrDoc, options);
-        };
-
-        if (solrResp.hasOwnProperty('response')) {
-          angular.forEach(solrResp.response.docs, function(solrDoc) {
-            var doc = parseSolrDoc(solrDoc);
-            thisSearcher.numFound = solrResp.response.numFound;
-            thisSearcher.docs.push(doc);
-          });
-        } else if (solrResp.hasOwnProperty('grouped')) {
-          angular.forEach(solrResp.grouped, function(groupedBy, groupedByName) {
-            thisSearcher.numFound = groupedBy.matches;
-            angular.forEach(groupedBy.groups, function(groupResp) {
-              var groupValue = groupResp.groupValue;
-              angular.forEach(groupResp.doclist.docs, function(solrDoc) {
-                var doc = parseSolrDoc(solrDoc, groupedByName, groupValue);
-                thisSearcher.docs.push(doc);
-                thisSearcher.addDocToGroup(groupedByName, groupValue, doc);
+          if (solrResp.hasOwnProperty('response')) {
+            angular.forEach(solrResp.response.docs, function(solrDoc) {
+              var doc = parseSolrDoc(solrDoc);
+              thisSearcher.numFound = solrResp.response.numFound;
+              thisSearcher.docs.push(doc);
+            });
+          } else if (solrResp.hasOwnProperty('grouped')) {
+            angular.forEach(solrResp.grouped, function(groupedBy, groupedByName) {
+              thisSearcher.numFound = groupedBy.matches;
+              angular.forEach(groupedBy.groups, function(groupResp) {
+                var groupValue = groupResp.groupValue;
+                angular.forEach(groupResp.doclist.docs, function(solrDoc) {
+                  var doc = parseSolrDoc(solrDoc, groupedByName, groupValue);
+                  thisSearcher.docs.push(doc);
+                  thisSearcher.addDocToGroup(groupedByName, groupValue, doc);
+                });
               });
             });
-          });
-        }
-      }, function error() {
-        activeQueries.count--;
-        thisSearcher.inError = true;
-        $q.reject();
+          }
+          resolve();
+        }, function error(msg) {
+          activeQueries.count--;
+          thisSearcher.inError = true;
+          msg.searchError = 'Error with Solr query or server. Contact Solr directly to inspect the error';
+          reject(msg);
+        });
       });
+
     }
 
     function explainOther (otherQuery, fieldSpec) {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2385,6 +2385,40 @@ angular.module('o19s.splainer-search')
         }
       };
 
+      var formatError = function(msg) {
+          var errorMsg = '';
+          if (msg) {
+            if (msg.status >= 400) {
+              errorMsg = 'HTTP Error: ' + msg.status + ' ' + msg.statusText;
+            }
+            if (msg.status > 0) {
+              if (msg.hasOwnProperty('data') && msg.data) {
+
+                if (msg.data.hasOwnProperty('error')) {
+                  errorMsg += '\n' + JSON.stringify(msg.data.error, null, 2);
+                }
+                if (msg.data.hasOwnProperty('_shards')) {
+                  angular.forEach(msg.data._shards.failures, function(failure) {
+                    errorMsg += '\n' + JSON.stringify(failure, null, 2);
+                  });
+                }
+
+              }
+            }
+            else if (msg.status === -1) {
+              errorMsg +=  'Network Error! (host not found)\n';
+              errorMsg += '\n';
+              errorMsg +=  'or CORS needs to be configured for your Elasticsearch\n';
+              errorMsg +=  '\n';
+              errorMsg +=  'Enable CORS in elasticsearch.yml:\n';
+              errorMsg += '\n';
+              errorMsg += 'http.cors.allow-origin: "/.*/"\n';
+              errorMsg += 'http.cors.enabled: true\n';
+            }
+          }
+          return errorMsg;
+      };
+
       // Build URL with params if any
       // Eg. without params:  /_search
       // Eg. with params:     /_search?size=5&from=5
@@ -2421,12 +2455,12 @@ angular.module('o19s.splainer-search')
         });
 
         if ( angular.isDefined(data._shards) && data._shards.failed > 0 ) {
-          return $q.reject(data._shards.failures[0]);
+          return $q.reject(formatError(httpConfig));
         }
       }, function error(msg) {
         activeQueries.count--;
         self.inError = true;
-        return $q.reject(msg);
+        return $q.reject(formatError(msg));
       });
     } // end of search()
 
@@ -2976,6 +3010,7 @@ angular.module('o19s.splainer-search')
       'activeQueries',
       'defaultSolrConfig',
       'solrSearcherPreprocessorSvc',
+      '$q',
       SolrSearcherFactory
     ]);
 
@@ -2983,7 +3018,7 @@ angular.module('o19s.splainer-search')
     $http,
     SolrDocFactory, SearcherFactory,
     activeQueries, defaultSolrConfig,
-    solrSearcherPreprocessorSvc
+    solrSearcherPreprocessorSvc, $q
   ) {
     var Searcher = function(options) {
       SearcherFactory.call(this, options, solrSearcherPreprocessorSvc);
@@ -3096,7 +3131,8 @@ angular.module('o19s.splainer-search')
       };
 
       activeQueries.count++;
-      return $http.jsonp(url).success(function(solrResp) {
+      return $http.jsonp(url).then(function success(resp) {
+        var solrResp = resp.data;
         activeQueries.count--;
 
         var explDict  = getExplData(solrResp);
@@ -3137,9 +3173,10 @@ angular.module('o19s.splainer-search')
             });
           });
         }
-      }).error(function() {
+      }, function error() {
         activeQueries.count--;
         thisSearcher.inError = true;
+        $q.reject();
       });
     }
 

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -116,10 +116,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
       .then(function success() {
         errorCalled--;
       }, function failure(msg) {
-        expect(msg.indexOf('HTTP')).toBe(-1);
-        expect(msg.indexOf('200')).toBe(-1);
-        expect(msg.indexOf('foo')).toBeGreaterThan(-1);
-        expect(msg.indexOf('your query just plain stunk')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('HTTP')).toBe(-1);
+        expect(msg.searchError.indexOf('200')).toBe(-1);
+        expect(msg.searchError.indexOf('foo')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('your query just plain stunk')).toBeGreaterThan(-1);
         errorCalled++;
       });
 
@@ -139,10 +139,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
       .then(function success() {
         errorCalled--;
       }, function failure(msg) {
-        expect(msg.indexOf('HTTP')).toBeGreaterThan(-1);
-        expect(msg.indexOf('400')).toBeGreaterThan(-1);
-        expect(msg.indexOf('someMsg')).toBeGreaterThan(-1);
-        expect(msg.indexOf('your query just plain stunk')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('HTTP')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('400')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('someMsg')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('your query just plain stunk')).toBeGreaterThan(-1);
         errorCalled++;
       });
 
@@ -161,8 +161,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
       .then(function success() {
         errorCalled--;
       }, function failure(msg) {
-        expect(msg.indexOf('Network Error')).toBeGreaterThan(-1);
-        expect(msg.indexOf('CORS')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('Network Error')).toBeGreaterThan(-1);
+        expect(msg.searchError.indexOf('CORS')).toBeGreaterThan(-1);
         errorCalled++;
       });
 
@@ -799,7 +799,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       .then(function success() {
         errorCalled--;
       }, function failure(msg) {
-        expect(msg).toContain("ElasticsearchIllegalArgumentException[field [cast] isn't a leaf field]");
+        expect(msg.searchError).toContain("ElasticsearchIllegalArgumentException[field [cast] isn't a leaf field]");
         errorCalled++;
       });
 

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -105,10 +105,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
       expect(called).toEqual(1);
     });
 
-    it('reports errors for the search', function() {
-      var errorMsg = 'your query just plain stunk';
+    it('reports pretty printed errors for ES errors but HTTP success', function() {
+      var errorMsg = {hits: [], _shards: {failed: 1, failures: [{foo: 'your query just plain stunk'}]}};
       $httpBackend.expectPOST(mockEsUrl).
-      respond(400, errorMsg);
+      respond(200, errorMsg);
 
       var errorCalled = 0;
 
@@ -116,7 +116,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
       .then(function success() {
         errorCalled--;
       }, function failure(msg) {
-        expect(msg.data).toBe(errorMsg);
+        expect(msg.indexOf('HTTP')).toBe(-1);
+        expect(msg.indexOf('200')).toBe(-1);
+        expect(msg.indexOf('foo')).toBeGreaterThan(-1);
+        expect(msg.indexOf('your query just plain stunk')).toBeGreaterThan(-1);
         errorCalled++;
       });
 
@@ -124,6 +127,49 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.verifyNoOutstandingExpectation();
       expect(errorCalled).toEqual(1);
     });
+
+    it('reports pretty printed errors for HTTP errors', function() {
+      var errorMsg = {'someMsg': 'your query just plain stunk'};
+      $httpBackend.expectPOST(mockEsUrl).
+      respond(400, {error: errorMsg});
+
+      var errorCalled = 0;
+
+      searcher.search()
+      .then(function success() {
+        errorCalled--;
+      }, function failure(msg) {
+        expect(msg.indexOf('HTTP')).toBeGreaterThan(-1);
+        expect(msg.indexOf('400')).toBeGreaterThan(-1);
+        expect(msg.indexOf('someMsg')).toBeGreaterThan(-1);
+        expect(msg.indexOf('your query just plain stunk')).toBeGreaterThan(-1);
+        errorCalled++;
+      });
+
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+      expect(errorCalled).toEqual(1);
+    });
+
+    it('network or CORS error', function() {
+      $httpBackend.expectPOST(mockEsUrl).
+      respond(-1);
+
+      var errorCalled = 0;
+
+      searcher.search()
+      .then(function success() {
+        errorCalled--;
+      }, function failure(msg) {
+        expect(msg.indexOf('Network Error')).toBeGreaterThan(-1);
+        expect(msg.indexOf('CORS')).toBeGreaterThan(-1);
+        errorCalled++;
+      });
+
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+      expect(errorCalled).toEqual(1);
+    })
 
     it('sets the proper headers for auth', function() {
       searcher = searchSvc.createSearcher(
@@ -753,7 +799,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       .then(function success() {
         errorCalled--;
       }, function failure(msg) {
-        expect(msg.reason).toBe("ElasticsearchIllegalArgumentException[field [cast] isn't a leaf field]");
+        expect(msg).toContain("ElasticsearchIllegalArgumentException[field [cast] isn't a leaf field]");
         errorCalled++;
       });
 

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -1074,6 +1074,32 @@ describe('Service: searchSvc: Solr', function () {
     });
   });
 
+  describe('errors', function() {
+    var fieldSpec = null;
+    var searcher = null;
+
+    beforeEach(function() {
+      fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+                                                  mockSolrParams, mockQueryText);
+    });
+
+    it('adds searchError text', function() {
+      $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
+                              .respond(-1);
+      var errorCnt = 0;
+      searcher.search().then(function() {
+        errorCnt--;
+      },
+      function error(msg) {
+        errorCnt++;
+        expect(msg.searchError.length).toBeGreaterThan(1);
+      });
+      $httpBackend.flush();
+      expect(errorCnt).toBe(1);
+    });
+  });
+
   describe('paging', function() {
     var fullSolrResp = {'responseHeader':{
       'status':0,


### PR DESCRIPTION
This pull request places a consistent "searchError" on a failed message. This gives a rather dev-centric error message about what failed. The remainder of the body (with http status codes, etc) are still passed on in case something useful went on or the user of this library wants to craft a better, less dev-focussed message.
## Acceptance Criteria
- Existing error processing code in Quepid/Splainer works
- A property "searchError" is added to every angular $http error which contains something useful
