### PR TITLE
Ignores spurious function_score query 

### DIFF
--- a/services/baseExplainSvc.js
+++ b/services/baseExplainSvc.js
@@ -18,7 +18,10 @@ angular.module('o19s.splainer-search')
         }
         this.children = [];
         angular.forEach(details, function(detail) {
-          datExplain.children.push(explFactory(detail));
+          var expl = explFactory(detail);
+          if (expl) {
+            datExplain.children.push(expl);
+          }
         });
 
         /* Each explain defines influencers,

--- a/services/explainSvc.js
+++ b/services/explainSvc.js
@@ -21,7 +21,6 @@ angular.module('o19s.splainer-search')
       var ProductExplain = queryExplainSvc.ProductExplain;
       var MinExplain = queryExplainSvc.MinExplain;
       var EsFieldFunctionQueryExplain = queryExplainSvc.EsFieldFunctionQueryExplain;
-      var PrefixExplain = queryExplainSvc.PrefixExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -106,8 +105,8 @@ angular.module('o19s.splainer-search')
           return new EsFieldFunctionQueryExplain(explJson);
         }
         else if (prefixMatch && prefixMatch.length > 1) {
-          PrefixExplain.prototype = base;
-          return new PrefixExplain(explJson);
+          WeightExplain.prototype = base;
+          return new WeightExplain(explJson);
         }
         else if (description.startsWith('match on required clause') || description.startsWith('match filter')) {
           return IGNORED; // because Elasticsearch funciton queries filter when they apply boosts (this doesn't matter in scoring)

--- a/services/explainSvc.js
+++ b/services/explainSvc.js
@@ -21,6 +21,7 @@ angular.module('o19s.splainer-search')
       var ProductExplain = queryExplainSvc.ProductExplain;
       var MinExplain = queryExplainSvc.MinExplain;
       var EsFieldFunctionQueryExplain = queryExplainSvc.EsFieldFunctionQueryExplain;
+      var PrefixExplain = queryExplainSvc.PrefixExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -52,6 +53,7 @@ angular.module('o19s.splainer-search')
       };
 
       var tieRegex = /max plus ([0-9.]+) times/;
+      var prefixRegex = /\:.*?\*(\^.+?)?, product of/;
       var createExplain = function(explJson) {
         explJson = replaceBadJson(explJson);
         var base = new Explain(explJson, createExplain);
@@ -59,6 +61,7 @@ angular.module('o19s.splainer-search')
         var details = [];
         var IGNORED = null;
         var tieMatch = description.match(tieRegex);
+        var prefixMatch = description.match(prefixRegex);
         if (explJson.hasOwnProperty('details')) {
           details = explJson.details;
         }
@@ -101,6 +104,10 @@ angular.module('o19s.splainer-search')
         else if (description.startsWith('Function for field')) {
           EsFieldFunctionQueryExplain.prototype = base;
           return new EsFieldFunctionQueryExplain(explJson);
+        }
+        else if (prefixMatch && prefixMatch.length > 1) {
+          PrefixExplain.prototype = base;
+          return new PrefixExplain(explJson);
         }
         else if (description.startsWith('match on required clause') || description.startsWith('match filter')) {
           return IGNORED; // because Elasticsearch funciton queries filter when they apply boosts (this doesn't matter in scoring)

--- a/services/explainSvc.js
+++ b/services/explainSvc.js
@@ -21,6 +21,7 @@ angular.module('o19s.splainer-search')
       var ProductExplain = queryExplainSvc.ProductExplain;
       var MinExplain = queryExplainSvc.MinExplain;
       var EsFieldFunctionQueryExplain = queryExplainSvc.EsFieldFunctionQueryExplain;
+      var EsFuncWeightExplain = queryExplainSvc.EsFuncWeightExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -118,6 +119,10 @@ angular.module('o19s.splainer-search')
         }
         else if (description.hasSubstr('constant score') && description.hasSubstr('no function provided')) {
           return IGNORED;
+        }
+        else if (description === 'weight') {
+          EsFuncWeightExplain.prototype = base;
+          return new EsFuncWeightExplain(explJson);
         }
         else if (tieMatch && tieMatch.length > 1) {
           var tie = parseFloat(tieMatch[1]);

--- a/services/queryExplainSvc.js
+++ b/services/queryExplainSvc.js
@@ -94,15 +94,8 @@ angular.module('o19s.splainer-search')
 
       };
 
-      this.IgnoredExplain = function(/*explJson*/) {
-        this.realExplanation = '';
-        this.vectorize = function() {
-          var rVal = vectorSvc.create();
-          return rVal;
-        };
-
-        this.influencers = function() {
-        };
+      this.PrefixExplain = function(explJson) {
+        this.realExplanation = explJson.description.replace(/, product of\:$/, '');
       };
 
       this.MinExplain = function() {

--- a/services/queryExplainSvc.js
+++ b/services/queryExplainSvc.js
@@ -94,6 +94,17 @@ angular.module('o19s.splainer-search')
 
       };
 
+      this.IgnoredExplain = function(/*explJson*/) {
+        this.realExplanation = '';
+        this.vectorize = function() {
+          var rVal = vectorSvc.create();
+          return rVal;
+        };
+
+        this.influencers = function() {
+        };
+      };
+
       this.MinExplain = function() {
         this.realExplaination = 'Minimum Of:';
 

--- a/services/queryExplainSvc.js
+++ b/services/queryExplainSvc.js
@@ -17,6 +17,10 @@ angular.module('o19s.splainer-search')
         this.realExplanation = 'Constant Scored Query';
       };
 
+      this.EsFuncWeightExplain = function(explJson) {
+        this.realExplanation = 'f( -- constant weight -- ) = ' + explJson.value;
+      };
+
       var shallowArrayCopy = function(src) {
         return src.slice(0);
       };

--- a/services/queryExplainSvc.js
+++ b/services/queryExplainSvc.js
@@ -37,6 +37,11 @@ angular.module('o19s.splainer-search')
           this.realExplanation = match[1];
         } else {
           this.realExplanation = description;
+          var prodOf = ', product of:';
+          if (description.endsWith(prodOf)) {
+            var len = description.length - prodOf.length;
+            this.realExplanation = description.substring(0, len);
+          }
         }
 
         this.hasMatch = function() {
@@ -92,10 +97,6 @@ angular.module('o19s.splainer-search')
         });
         this.realExplanation = explText;
 
-      };
-
-      this.PrefixExplain = function(explJson) {
-        this.realExplanation = explJson.description.replace(/, product of\:$/, '');
       };
 
       this.MinExplain = function() {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -462,6 +462,7 @@ angular.module('o19s.splainer-search')
       var ProductExplain = queryExplainSvc.ProductExplain;
       var MinExplain = queryExplainSvc.MinExplain;
       var EsFieldFunctionQueryExplain = queryExplainSvc.EsFieldFunctionQueryExplain;
+      var EsFuncWeightExplain = queryExplainSvc.EsFuncWeightExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -559,6 +560,10 @@ angular.module('o19s.splainer-search')
         }
         else if (description.hasSubstr('constant score') && description.hasSubstr('no function provided')) {
           return IGNORED;
+        }
+        else if (description === 'weight') {
+          EsFuncWeightExplain.prototype = base;
+          return new EsFuncWeightExplain(explJson);
         }
         else if (tieMatch && tieMatch.length > 1) {
           var tie = parseFloat(tieMatch[1]);
@@ -1031,6 +1036,10 @@ angular.module('o19s.splainer-search')
 
       this.ConstantScoreExplain = function() {
         this.realExplanation = 'Constant Scored Query';
+      };
+
+      this.EsFuncWeightExplain = function(explJson) {
+        this.realExplanation = 'f( -- constant weight -- ) = ' + explJson.value;
       };
 
       var shallowArrayCopy = function(src) {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -462,7 +462,6 @@ angular.module('o19s.splainer-search')
       var ProductExplain = queryExplainSvc.ProductExplain;
       var MinExplain = queryExplainSvc.MinExplain;
       var EsFieldFunctionQueryExplain = queryExplainSvc.EsFieldFunctionQueryExplain;
-      var PrefixExplain = queryExplainSvc.PrefixExplain;
 
       var FieldWeightExplain = simExplainSvc.FieldWeightExplain;
       var QueryWeightExplain = simExplainSvc.QueryWeightExplain;
@@ -547,8 +546,8 @@ angular.module('o19s.splainer-search')
           return new EsFieldFunctionQueryExplain(explJson);
         }
         else if (prefixMatch && prefixMatch.length > 1) {
-          PrefixExplain.prototype = base;
-          return new PrefixExplain(explJson);
+          WeightExplain.prototype = base;
+          return new WeightExplain(explJson);
         }
         else if (description.startsWith('match on required clause') || description.startsWith('match filter')) {
           return IGNORED; // because Elasticsearch funciton queries filter when they apply boosts (this doesn't matter in scoring)
@@ -1054,6 +1053,11 @@ angular.module('o19s.splainer-search')
           this.realExplanation = match[1];
         } else {
           this.realExplanation = description;
+          var prodOf = ', product of:';
+          if (description.endsWith(prodOf)) {
+            var len = description.length - prodOf.length;
+            this.realExplanation = description.substring(0, len);
+          }
         }
 
         this.hasMatch = function() {
@@ -1109,10 +1113,6 @@ angular.module('o19s.splainer-search')
         });
         this.realExplanation = explText;
 
-      };
-
-      this.PrefixExplain = function(explJson) {
-        this.realExplanation = explJson.description.replace(/, product of\:$/, '');
       };
 
       this.MinExplain = function() {


### PR DESCRIPTION
Elasticsearch's function_score queries layer on all kinds of cruft that
are typically special cases. For example the "max_boost" is an argument
taht can put a ceiling on your boost. Also you always have a
"queryBoost" of 1, even if you didn't specify any kind of boost.

Experimenting with o19s's blog, this seems to give the sanest results
for function_score queries
