### PR TITLE
Trims the output of "source" to pertinent fields

### DIFF
--- a/factories/esDocFactory.js
+++ b/factories/esDocFactory.js
@@ -74,7 +74,16 @@
       // Usually you would return _source, but since we are specifying the
       // fields to display, ES only returns those specific fields.
       // And we are assigning the fields to the doc itself in this case.
-      return angular.copy(self);
+      var src = {};
+      angular.forEach(self, function(value, field) {
+        if (!angular.isFunction(value)) {
+          src[field] = value;
+        }
+      });
+      delete src.doc;
+      delete src._explanation;
+      delete src.highlight;
+      return src;
     }
 
     function highlight (docId, fieldName, preText, postText) {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2212,7 +2212,16 @@ angular.module('o19s.splainer-search')
       // Usually you would return _source, but since we are specifying the
       // fields to display, ES only returns those specific fields.
       // And we are assigning the fields to the doc itself in this case.
-      return angular.copy(self);
+      var src = {};
+      angular.forEach(self, function(value, field) {
+        if (!angular.isFunction(value)) {
+          src[field] = value;
+        }
+      });
+      delete src.doc;
+      delete src._explanation;
+      delete src.highlight;
+      return src;
     }
 
     function highlight (docId, fieldName, preText, postText) {


### PR DESCRIPTION
When implementing ES in splainer, the default fieldSpec is "*". This means return every field. Which gives results like the following (lots of [object Object])

![image](https://cloud.githubusercontent.com/assets/629060/14434622/de67de4e-ffe1-11e5-8ed6-30ed23b4d5a3.png)

In investigating, I noted that "source()" just copies self. Which works most of the time. However, its a simple fix to trim out some of the cruft from the output. 
## Acceptance Criteria

`source()` doesn't return some of the "metadata" like properties of the EsDoc object like `doc` or `_explanation`.
