### PR TITLE
Fixes #32 -- Allows URI decoding to fail gracefully

### DIFF
--- a/services/solrUrlSvc.js
+++ b/services/solrUrlSvc.js
@@ -15,6 +15,7 @@ angular.module('o19s.splainer-search')
         }
         return url;
       }
+
       this.buildUrl = function(url, urlArgs) {
         url = fixURLProtocol(url);
         var baseUrl = url + '?';
@@ -56,7 +57,12 @@ angular.module('o19s.splainer-search')
           if (nameAndValue.length >= 2) {
             var name  = nameAndValue[0];
             var value = nameAndValue[1];
-            var decodedValue = decodeURIComponent(value);
+            var decodedValue = value;
+            try {
+              decodedValue = decodeURIComponent(value);
+            } catch (URIError) { // expected if the string is not actually URL encoded has a stray %, ie mm=50%
+              console.warn('Parameter ' + value + ' could not be URI decoded, this might be ok');
+            }
             if (!rVal.hasOwnProperty(name)) {
               rVal[name] = [decodedValue];
             } else {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1703,6 +1703,7 @@ angular.module('o19s.splainer-search')
         }
         return url;
       }
+
       this.buildUrl = function(url, urlArgs) {
         url = fixURLProtocol(url);
         var baseUrl = url + '?';
@@ -1744,7 +1745,12 @@ angular.module('o19s.splainer-search')
           if (nameAndValue.length >= 2) {
             var name  = nameAndValue[0];
             var value = nameAndValue[1];
-            var decodedValue = decodeURIComponent(value);
+            var decodedValue = value;
+            try {
+              decodedValue = decodeURIComponent(value);
+            } catch (URIError) { // expected if the string is not actually URL encoded has a stray %, ie mm=50%
+              console.warn('Parameter ' + value + ' could not be URI decoded, this might be ok');
+            }
             if (!rVal.hasOwnProperty(name)) {
               rVal[name] = [decodedValue];
             } else {

--- a/test/spec/solrUrlSvc.js
+++ b/test/spec/solrUrlSvc.js
@@ -106,6 +106,26 @@ describe('Service: solrUrlSvc', function () {
       expect(parsedSolrUrl.requestHandler).toEqual('select');
       expect(parsedSolrUrl.solrArgs.q).toContain('*:*');
     });
+
+    it('avoids escaping obviously non URI decoded params (ie mm=50%)', function() {
+      var urlStr = 'http://localhost:8080/la-solr/tt/select?mm=50%';
+      var parsedSolrUrl = solrUrlSvc.parseSolrUrl(urlStr);
+      expect(parsedSolrUrl.protocol).toEqual('http:');
+      expect(parsedSolrUrl.host).toEqual('localhost:8080');
+      expect(parsedSolrUrl.collectionName).toEqual('tt');
+      expect(parsedSolrUrl.requestHandler).toEqual('select');
+      expect(parsedSolrUrl.solrArgs.mm).toContain('50%');
+    });
+
+    it('escapes URI decoded params', function() {
+      var urlStr = 'http://localhost:8080/la-solr/tt/select?mm=50%25';
+      var parsedSolrUrl = solrUrlSvc.parseSolrUrl(urlStr);
+      expect(parsedSolrUrl.protocol).toEqual('http:');
+      expect(parsedSolrUrl.host).toEqual('localhost:8080');
+      expect(parsedSolrUrl.collectionName).toEqual('tt');
+      expect(parsedSolrUrl.requestHandler).toEqual('select');
+      expect(parsedSolrUrl.solrArgs.mm).toContain('50%');
+    });
   });
 
   describe('build URL', function() {


### PR DESCRIPTION
If you happen to put mm=50% in a Solr query in splainer, splainer just
gets stuck. This is because URI decoding throws an excpetion. the
decodeURIcomponent can tell this isn't a legit decoded URI component.
Unfortunately for Solr users, its easy to have a giant query URL where
mm=50% is buried in at character 500. Its a royal pain to find that mm
and manually escape it. Moreover, we advertise you can just "paste a URL
into splainer" and it'll work.

All that to say, we should be more forgiving in this error case.
