### PR TITLE
Keeps basic auth from being stripped from URLs

### DIFF
--- a/services/esUrlSvc.js
+++ b/services/esUrlSvc.js
@@ -131,7 +131,11 @@ angular.module('o19s.splainer-search')
       }
 
       function buildBaseUrl (uri) {
-        var url = uri.protocol + '://' + uri.host;
+        var url = uri.protocol + '://';
+        if (uri.password && uri.username) {
+          url += uri.username + ':' + uri.password + '@';
+        }
+        url += (uri.host);
 
         return url;
       }

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -420,7 +420,11 @@ angular.module('o19s.splainer-search')
       }
 
       function buildBaseUrl (uri) {
-        var url = uri.protocol + '://' + uri.host;
+        var url = uri.protocol + '://';
+        if (uri.password && uri.username) {
+          url += uri.username + ':' + uri.password + '@';
+        }
+        url += (uri.host);
 
         return url;
       }

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -187,19 +187,20 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.flush();
       $httpBackend.verifyNoOutstandingExpectation();
       expect(errorCalled).toEqual(1);
-    })
+    });
 
     it('sets the proper headers for auth', function() {
+      var authEsUrl = 'http://username:password@localhost:9200/statedecoded/_search';
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
-        'http://username:password@localhost:9200/statedecoded/_search',
+        authEsUrl,
         mockEsParams,
         mockQueryText,
         {},
         'es'
       );
 
-      $httpBackend.expectPOST(mockEsUrl, undefined, function(headers) {
+      $httpBackend.expectPOST(authEsUrl, undefined, function(headers) {
         return headers['Authorization'] == 'Basic ' + btoa('username:password');
       }).
       respond(200, mockResults);

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -59,6 +59,13 @@ describe('Service: esUrlSvc', function () {
 
       expect(uri.username).toBe('username');
       expect(uri.password).toBe('password');
+
+      var rebuiltUri = esUrlSvc.buildUrl(uri);
+      var uriAgain = esUrlSvc.parseUrl(rebuiltUri);
+
+      expect(uriAgain.username).toBe('username');
+      expect(uriAgain.password).toBe('password');
+
     });
 
     it('understands when bulk endpoint used', function() {


### PR DESCRIPTION
Splainer parses the user provided URL then rebuilds it when displaying it to the user. This patch keeps the basic auth stuff on the URL. Without it, Splainer isn't very useful as after your first tweak you lose basic auth info so subsequent searches stop working.
