### PR TITLE
Prevents re-escaping % when it's part of an escape char.

### DIFF
--- a/services/solrUrlSvc.js
+++ b/services/solrUrlSvc.js
@@ -29,14 +29,22 @@ angular.module('o19s.splainer-search')
        * */
       this.formatSolrArgs = function(argsObj) {
         var rVal = '';
+
         angular.forEach(argsObj, function(values, param) {
-          angular.forEach(values, function(value) {
-            rVal += param + '=' + value + '&';
-          });
+          if ( angular.isString(values) ) {
+            rVal += param + '=' + values + '&';
+          } else {
+            angular.forEach(values, function(value) {
+              rVal += param + '=' + value + '&';
+            });
+          }
         });
-        // percentages need to be escaped before
-        // url escaping
-        rVal = rVal.replace(/%/g, '%25');
+
+        // percentages need to be escaped before url escaping
+        // but only if it is not part of a percent encoding character
+        // https://en.wikipedia.org/wiki/Percent-encoding
+        rVal = rVal.replace(/\%(?!(2|3|4|5))/g, '%25');
+
         return rVal.slice(0, -1); // take out last & or trailing ? if no args
       };
 

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -1735,14 +1735,21 @@ angular.module('o19s.splainer-search')
        * */
       this.formatSolrArgs = function(argsObj) {
         var rVal = '';
+
         angular.forEach(argsObj, function(values, param) {
-          angular.forEach(values, function(value) {
-            rVal += param + '=' + value + '&';
-          });
+          if ( angular.isString(values) ) {
+            rVal += param + '=' + values + '&';
+          } else {
+            angular.forEach(values, function(value) {
+              rVal += param + '=' + value + '&';
+            });
+          }
         });
-        // percentages need to be escaped before
-        // url escaping
-        rVal = rVal.replace(/%/g, '%25');
+
+        // percentages need to be escaped before url escaping
+        // but only if it is not part of a percent encoding character
+        rVal = rVal.replace(/\%(?!(2|3|4|5))/g, '%25');
+
         return rVal.slice(0, -1); // take out last & or trailing ? if no args
       };
 

--- a/test/spec/solrUrlSvc.js
+++ b/test/spec/solrUrlSvc.js
@@ -133,6 +133,37 @@ describe('Service: solrUrlSvc', function () {
       var url = solrUrlSvc.buildUrl('www.example.com', {a: 'b', c: 'd'});
       expect(url).toEqual('http://www.example.com?a=b&c=d');
     });
+
+    it('appends the args properly', function() {
+      var url = solrUrlSvc.buildUrl('www.example.com', {a: 'bb', c: 'd'});
+      expect(url).toEqual('http://www.example.com?a=bb&c=d');
+
+      url = solrUrlSvc.buildUrl('www.example.com', {a: ['b', 'b'], c: 'd'});
+      expect(url).toEqual('http://www.example.com?a=b&a=b&c=d');
+    });
+
+    it('does not re-escape escaped values inside double quotes', function() {
+      var urlStr = 'http://localhost:8080/solr/index/select';
+      var args   = {
+        q:  '*:*',
+        bq: '(*:* AND -meta_contentType_ms:"Faculty%20%26%20Research%20Work")^100',
+        p:  '50%',
+        p1: '"Faculty%20%26%20Research%20Work"'
+      };
+      var url    = solrUrlSvc.buildUrl(urlStr, args);
+
+      expect(url).toEqual('http://localhost:8080/solr/index/select?q=*:*&bq=(*:* AND -meta_contentType_ms:"Faculty%20%26%20Research%20Work")^100&p=50%25&p1="Faculty%20%26%20Research%20Work"');
+
+      args   = {
+        q:  '*:*',
+        bq: '(*:* AND -meta_contentType_ms:"Faculty %26 Research Work")^100',
+        p:  '50%',
+        p1: '"Faculty %26 Research Work"'
+      };
+      url    = solrUrlSvc.buildUrl(urlStr, args);
+
+      expect(url).toEqual('http://localhost:8080/solr/index/select?q=*:*&bq=(*:* AND -meta_contentType_ms:"Faculty %26 Research Work")^100&p=50%25&p1="Faculty %26 Research Work"');
+    })
   });
 
   describe('escape user query', function() {


### PR DESCRIPTION
if the query params contains something like this:

```
&bq=(*:* AND -meta_contentType_ms:"Faculty %26 Research Work")`
```

then Quepid should not escape the `%` and turn it into 

```
&bq=(*:* AND -meta_contentType_ms:"Faculty %2526 Research Work")
```