### PR TITLE
ES 5 Support

### DIFF
--- a/factories/docFactory.js
+++ b/factories/docFactory.js
@@ -57,7 +57,11 @@
             return 'stored_fields';
           }
         } else {
-          return 'fields';
+          if ( self.hasOwnProperty('_source') ) {
+            return '_source';
+          } else {
+            return 'fields';
+          }
         }
       }
 

--- a/factories/docFactory.js
+++ b/factories/docFactory.js
@@ -12,11 +12,14 @@
 
       angular.copy(doc, self);
 
-      self.doc        = doc;
+      self.doc             = doc;
 
-      self.groupedBy  = groupedBy;
-      self.group      = group;
-      self.options    = options;
+      self.groupedBy       = groupedBy;
+      self.group           = group;
+      self.options         = options;
+      self.version         = version;
+      self.fieldsAttrName  = fieldsAttrName;
+      self.fieldsProperty  = fieldsProperty;
 
       function groupedBy () {
         if (opts.groupedBy === undefined) {
@@ -36,6 +39,30 @@
         } else {
           return opts.group;
         }
+      }
+
+      function version () {
+        if (opts.version === undefined) {
+          return null;
+        } else {
+          return opts.version;
+        }
+      }
+
+      function fieldsAttrName() {
+        if ( 5 <= self.version() ) {
+          if ( self.hasOwnProperty('_source') ) {
+            return '_source';
+          } else {
+            return 'stored_fields';
+          }
+        } else {
+          return 'fields';
+        }
+      }
+
+      function fieldsProperty() {
+        return self[self.fieldsAttrName()];
       }
     };
 

--- a/factories/esDocFactory.js
+++ b/factories/esDocFactory.js
@@ -15,7 +15,8 @@
       DocFactory.call(this, doc, options);
 
       var self = this;
-      angular.forEach(self.fields, function(fieldValue, fieldName) {
+
+      angular.forEach(self.fieldsProperty(), function(fieldValue, fieldName) {
         if ( fieldValue.length === 1 && typeof(fieldValue) === 'object' ) {
           self[fieldName] = fieldValue[0];
         } else {

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -117,15 +117,19 @@
       }
 
       if (apiMethod === 'get' ) {
+        var fieldList = self.fieldList.join(',');
+
         if ( 5 <= self.majorVersion() ) {
-          var fieldList = self.fieldList.join(',');
           /*jshint camelcase: false */
           esUrlSvc.setParams(uri, {
             stored_fields: fieldList,
             _source:       fieldList,
           });
         } else {
-          esUrlSvc.setParams(uri, { fields: self.fieldList.join(',') });
+          esUrlSvc.setParams(uri, {
+            fields:  fieldList,
+            _source: fieldList,
+          });
         }
       }
 

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -118,8 +118,12 @@
 
       if (apiMethod === 'get' ) {
         if ( 5 <= self.majorVersion() ) {
+          var fieldList = self.fieldList.join(',');
           /*jshint camelcase: false */
-          esUrlSvc.setParams(uri, { stored_fields: self.fieldList.join(',') });
+          esUrlSvc.setParams(uri, {
+            stored_fields: fieldList,
+            _source:       fieldList,
+          });
         } else {
           esUrlSvc.setParams(uri, { fields: self.fieldList.join(',') });
         }
@@ -213,6 +217,7 @@
             url:                self.url,
             explDict:           explDict,
             hlDict:             hlDict,
+            version:            self.majorVersion(),
           };
 
           return new EsDocFactory(doc, options);

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -100,7 +100,7 @@ angular.module('o19s.splainer-search')
         if ( 5 <= searcher.majorVersion() ) {
           self.fieldsParamNames = [ '_source', 'stored_fields' ];
         } else {
-          self.fieldsParamNames = [ 'fields' ];
+          self.fieldsParamNames = [ '_source', 'fields' ];
         }
       };
 

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -201,7 +201,8 @@ angular.module('o19s.splainer-search')
       var self = this;
 
       // Attributes
-      self.fieldsParamName = 'stored_fields'; // field name since ES 5.0
+      // field name since ES 5.0
+      self.fieldsParamNames = [ '_source', 'stored_fields' ];
 
       // Functions
       self.prepare  = prepare;
@@ -221,25 +222,27 @@ angular.module('o19s.splainer-search')
       };
 
       var prepareHighlighting = function (args, fields) {
-        if ( angular.isDefined(fields) && fields !== null && fields.hasOwnProperty('fields') ) {
-          fields = fields.fields;
+        if ( angular.isDefined(fields) && fields !== null ) {
+          if ( fields.hasOwnProperty('fields') ) {
+            fields = fields.fields;
+          }
+
+          if ( fields.length > 0 ) {
+            var hl = { fields: {} };
+
+            angular.forEach(fields, function(fieldName) {
+              hl.fields[fieldName] = { };
+            });
+
+            return hl;
+          }
         }
 
-        if ( angular.isDefined(fields) && fields !== null && fields.length > 0 ) {
-          var hl = { fields: {} };
-
-          angular.forEach(fields, function(fieldName) {
-            hl.fields[fieldName] = {};
-          });
-
-          return hl;
-        } else {
-          return {
-            fields: {
-              _all: {}
-            }
-          };
-        }
+        return {
+          fields: {
+            _all: {}
+          }
+        };
       };
 
       var preparePostRequest = function (searcher) {
@@ -257,15 +260,16 @@ angular.module('o19s.splainer-search')
         delete searcher.args.pager;
 
         var queryDsl        = replaceQuery(searcher.args, searcher.queryText);
-
-        if ( angular.isDefined(searcher.fieldList) && searcher.fieldList !== null ) {
-          queryDsl[self.fieldsParamName] = searcher.fieldList;
-        }
-
         queryDsl.explain    = true;
 
+        if ( angular.isDefined(searcher.fieldList) && searcher.fieldList !== null ) {
+          angular.forEach(self.fieldsParamNames, function(name) {
+            queryDsl[name] = searcher.fieldList;
+          });
+        }
+
         if ( !queryDsl.hasOwnProperty('highlight') ) {
-          queryDsl.highlight = prepareHighlighting(searcher.args, queryDsl[self.fieldsParamName]);
+          queryDsl.highlight = prepareHighlighting(searcher.args, queryDsl[self.fieldsParamNames[0]]);
         }
 
         searcher.queryDsl   = queryDsl;
@@ -287,9 +291,9 @@ angular.module('o19s.splainer-search')
 
       var setFieldsParamName = function(searcher) {
         if ( 5 <= searcher.majorVersion() ) {
-          self.fieldsParamName = 'stored_fields';
+          self.fieldsParamNames = [ '_source', 'stored_fields' ];
         } else {
-          self.fieldsParamName = 'fields';
+          self.fieldsParamNames = [ 'fields' ];
         }
       };
 
@@ -2193,11 +2197,14 @@ angular.module('o19s.splainer-search')
 
       angular.copy(doc, self);
 
-      self.doc        = doc;
+      self.doc             = doc;
 
-      self.groupedBy  = groupedBy;
-      self.group      = group;
-      self.options    = options;
+      self.groupedBy       = groupedBy;
+      self.group           = group;
+      self.options         = options;
+      self.version         = version;
+      self.fieldsAttrName  = fieldsAttrName;
+      self.fieldsProperty  = fieldsProperty;
 
       function groupedBy () {
         if (opts.groupedBy === undefined) {
@@ -2217,6 +2224,30 @@ angular.module('o19s.splainer-search')
         } else {
           return opts.group;
         }
+      }
+
+      function version () {
+        if (opts.version === undefined) {
+          return null;
+        } else {
+          return opts.version;
+        }
+      }
+
+      function fieldsAttrName() {
+        if ( 5 <= self.version() ) {
+          if ( self.hasOwnProperty('_source') ) {
+            return '_source';
+          } else {
+            return 'stored_fields';
+          }
+        } else {
+          return 'fields';
+        }
+      }
+
+      function fieldsProperty() {
+        return self[self.fieldsAttrName()];
       }
     };
 
@@ -2242,7 +2273,8 @@ angular.module('o19s.splainer-search')
       DocFactory.call(this, doc, options);
 
       var self = this;
-      angular.forEach(self.fields, function(fieldValue, fieldName) {
+
+      angular.forEach(self.fieldsProperty(), function(fieldValue, fieldName) {
         if ( fieldValue.length === 1 && typeof(fieldValue) === 'object' ) {
           self[fieldName] = fieldValue[0];
         } else {
@@ -2461,8 +2493,12 @@ angular.module('o19s.splainer-search')
 
       if (apiMethod === 'get' ) {
         if ( 5 <= self.majorVersion() ) {
+          var fieldList = self.fieldList.join(',');
           /*jshint camelcase: false */
-          esUrlSvc.setParams(uri, { stored_fields: self.fieldList.join(',') });
+          esUrlSvc.setParams(uri, {
+            stored_fields: fieldList,
+            _source:       fieldList,
+          });
         } else {
           esUrlSvc.setParams(uri, { fields: self.fieldList.join(',') });
         }
@@ -2556,6 +2592,7 @@ angular.module('o19s.splainer-search')
             url:                self.url,
             explDict:           explDict,
             hlDict:             hlDict,
+            version:            self.majorVersion(),
           };
 
           return new EsDocFactory(doc, options);

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -293,7 +293,7 @@ angular.module('o19s.splainer-search')
         if ( 5 <= searcher.majorVersion() ) {
           self.fieldsParamNames = [ '_source', 'stored_fields' ];
         } else {
-          self.fieldsParamNames = [ 'fields' ];
+          self.fieldsParamNames = [ '_source', 'fields' ];
         }
       };
 
@@ -2242,7 +2242,11 @@ angular.module('o19s.splainer-search')
             return 'stored_fields';
           }
         } else {
-          return 'fields';
+          if ( self.hasOwnProperty('_source') ) {
+            return '_source';
+          } else {
+            return 'fields';
+          }
         }
       }
 
@@ -2492,15 +2496,19 @@ angular.module('o19s.splainer-search')
       }
 
       if (apiMethod === 'get' ) {
+        var fieldList = self.fieldList.join(',');
+
         if ( 5 <= self.majorVersion() ) {
-          var fieldList = self.fieldList.join(',');
           /*jshint camelcase: false */
           esUrlSvc.setParams(uri, {
             stored_fields: fieldList,
             _source:       fieldList,
           });
         } else {
-          esUrlSvc.setParams(uri, { fields: self.fieldList.join(',') });
+          esUrlSvc.setParams(uri, {
+            fields:  fieldList,
+            _source: fieldList,
+          });
         }
       }
 

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -1002,7 +1002,9 @@ describe('Service: searchSvc: ElasticSearch', function() {
     var expectedExplainResponse = sumExplain;
 
     it('makes one search request and one explain request per resulting doc', function () {
-      var url = mockEsUrl + '?fields=' + mockFieldSpec.fieldList().join(',');
+      var fieldList = mockFieldSpec.fieldList().join(',');
+      var url       = mockEsUrl + '?fields=' + fieldList;
+      url += '&_source=' + fieldList;
       url += '&q=' + otherQuery;
       url += '&from=0&size=10';
 
@@ -1021,7 +1023,9 @@ describe('Service: searchSvc: ElasticSearch', function() {
     });
 
     it('sets the array of docs', function () {
-      var url = mockEsUrl + '?fields=' + mockFieldSpec.fieldList().join(',');
+      var fieldList = mockFieldSpec.fieldList().join(',');
+      var url       = mockEsUrl + '?fields=' + fieldList;
+      url += '&_source=' + fieldList;
       url += '&q=' + otherQuery;
       url += '&from=0&size=10';
 
@@ -1044,7 +1048,9 @@ describe('Service: searchSvc: ElasticSearch', function() {
     });
 
     it('paginates for explain other searches', function () {
-      var url = mockEsUrl + '?fields=' + mockFieldSpec.fieldList().join(',');
+      var fieldList = mockFieldSpec.fieldList().join(',');
+      var url       = mockEsUrl + '?fields=' + fieldList;
+      url += '&_source=' + fieldList;
       url += '&q=' + otherQuery;
       url += '&from=10&size=10';
 


### PR DESCRIPTION
Updates API to use both `_source` field to fetch fields from by default ad `stored_fields` in ES 5+ or `fields` otherwise.