### PR TITLE
Ignore Elasticsearch Version by requiring _source when using Elasticsearch

### DIFF
--- a/factories/docFactory.js
+++ b/factories/docFactory.js
@@ -50,19 +50,7 @@
       }
 
       function fieldsAttrName() {
-        if ( 5 <= self.version() ) {
-          if ( self.hasOwnProperty('_source') ) {
-            return '_source';
-          } else {
-            return 'stored_fields';
-          }
-        } else {
-          if ( self.hasOwnProperty('_source') ) {
-            return '_source';
-          } else {
-            return 'fields';
-          }
-        }
+        return '_source';
       }
 
       function fieldsProperty() {

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -122,12 +122,10 @@
         if ( 5 <= self.majorVersion() ) {
           /*jshint camelcase: false */
           esUrlSvc.setParams(uri, {
-            stored_fields: fieldList,
             _source:       fieldList,
           });
         } else {
           esUrlSvc.setParams(uri, {
-            fields:  fieldList,
             _source: fieldList,
           });
         }

--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -188,7 +188,7 @@
               errorMsg +=  '\n';
               errorMsg +=  'Enable CORS in elasticsearch.yml:\n';
               errorMsg += '\n';
-              errorMsg += 'http.cors.allow-origin: "/https?:\\/\\/(.*?\\.)?(quepid\\.com|splainer\\.io)/"';
+              errorMsg += 'http.cors.allow-origin: "/https?:\\/\\/(.*?\\.)?(quepid\\.com|splainer\\.io)/"\n';
               errorMsg += 'http.cors.enabled: true\n';
             }
             msg.searchError = errorMsg;

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -9,7 +9,7 @@ angular.module('o19s.splainer-search')
 
       // Attributes
       // field name since ES 5.0
-      self.fieldsParamNames = [ '_source', 'stored_fields' ];
+      self.fieldsParamNames = [ '_source'];
 
       // Functions
       self.prepare  = prepare;
@@ -96,12 +96,8 @@ angular.module('o19s.splainer-search')
         }
       };
 
-      var setFieldsParamName = function(searcher) {
-        if ( 5 <= searcher.majorVersion() ) {
-          self.fieldsParamNames = [ '_source', 'stored_fields' ];
-        } else {
-          self.fieldsParamNames = [ '_source', 'fields' ];
-        }
+      var setFieldsParamName = function() {
+        self.fieldsParamNames = [ '_source'];
       };
 
       function prepare (searcher) {

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -202,7 +202,7 @@ angular.module('o19s.splainer-search')
 
       // Attributes
       // field name since ES 5.0
-      self.fieldsParamNames = [ '_source', 'stored_fields' ];
+      self.fieldsParamNames = [ '_source'];
 
       // Functions
       self.prepare  = prepare;
@@ -289,12 +289,8 @@ angular.module('o19s.splainer-search')
         }
       };
 
-      var setFieldsParamName = function(searcher) {
-        if ( 5 <= searcher.majorVersion() ) {
-          self.fieldsParamNames = [ '_source', 'stored_fields' ];
-        } else {
-          self.fieldsParamNames = [ '_source', 'fields' ];
-        }
+      var setFieldsParamName = function() {
+        self.fieldsParamNames = [ '_source'];
       };
 
       function prepare (searcher) {
@@ -2491,12 +2487,10 @@ angular.module('o19s.splainer-search')
         if ( 5 <= self.majorVersion() ) {
           /*jshint camelcase: false */
           esUrlSvc.setParams(uri, {
-            stored_fields: fieldList,
             _source:       fieldList,
           });
         } else {
           esUrlSvc.setParams(uri, {
-            fields:  fieldList,
             _source: fieldList,
           });
         }

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2237,19 +2237,7 @@ angular.module('o19s.splainer-search')
       }
 
       function fieldsAttrName() {
-        if ( 5 <= self.version() ) {
-          if ( self.hasOwnProperty('_source') ) {
-            return '_source';
-          } else {
-            return 'stored_fields';
-          }
-        } else {
-          if ( self.hasOwnProperty('_source') ) {
-            return '_source';
-          } else {
-            return 'fields';
-          }
-        }
+        return '_source';
       }
 
       function fieldsProperty() {

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -1235,8 +1235,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
 
     it('makes one search request and one explain request per resulting doc', function () {
       var fieldList = mockFieldSpec.fieldList().join(',');
-      var url       = mockEsUrl + '?fields=' + fieldList;
-      url += '&_source=' + fieldList;
+      var url       = mockEsUrl;
+      url += '?_source=' + fieldList;
       url += '&q=' + otherQuery;
       url += '&from=0&size=10';
 
@@ -1256,8 +1256,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
 
     it('sets the array of docs', function () {
       var fieldList = mockFieldSpec.fieldList().join(',');
-      var url       = mockEsUrl + '?fields=' + fieldList;
-      url += '&_source=' + fieldList;
+      var url       = mockEsUrl;
+      url += '?_source=' + fieldList;
       url += '&q=' + otherQuery;
       url += '&from=0&size=10';
 
@@ -1281,8 +1281,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
 
     it('paginates for explain other searches', function () {
       var fieldList = mockFieldSpec.fieldList().join(',');
-      var url       = mockEsUrl + '?fields=' + fieldList;
-      url += '&_source=' + fieldList;
+      var url       = mockEsUrl;
+      url += '?_source=' + fieldList;
       url += '&q=' + otherQuery;
       url += '&from=10&size=10';
 
@@ -1335,36 +1335,5 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.flush();
     });
 
-    describe('prior to 5.0', function() {
-      beforeEach(inject(function () {
-        searcher = searchSvc.createSearcher(
-          mockFieldSpec.fieldList().join(','),
-          mockEsUrl,
-          mockEsParams,
-          mockQueryText,
-          { version: '2.0' },
-          'es'
-        );
-      }));
-
-      it('sets the appropriate version and uses the "fields" params', function() {
-        expect(searcher.config.version).toEqual('2.0');
-
-        var expectedParams = {
-          fields: mockFieldSpec.fieldList().join(',')
-        };
-
-        $httpBackend.when('POST', mockEsUrl,
-          function(postData) {
-            var jsonData = JSON.parse(postData);
-            expect(jsonData.fields).toBe(expectedParams.fields);
-            return true;
-          }
-        ).respond(200, mockES4Results);
-
-        searcher.search();
-        $httpBackend.flush();
-      });
-    });
   });
 });

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -50,7 +50,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
           '_type':  'law',
           '_id':    'l_1',
           '_score': 5.0,
-          'fields': {
+          '_source': {
             'field':  ['1--field value'],
             'field1': ['1--field1 value']
           },
@@ -60,7 +60,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
           '_type':  'law',
           '_id':    'l_1',
           '_score': 3.0,
-          'fields': {
+          '_source': {
             'field':  ['2--field value'],
             'field1': ['2--field1 value']
           }
@@ -79,7 +79,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
           '_type':  'law',
           '_id':    'l_1',
           '_score': 5.0,
-          'stored_fields': {
+          '_source': {
             'field':  ['1--field value'],
             'field1': ['1--field1 value']
           },
@@ -89,7 +89,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
           '_type':  'law',
           '_id':    'l_1',
           '_score': 3.0,
-          'stored_fields': {
+          '_source': {
             'field':  ['2--field value'],
             'field1': ['2--field1 value']
           }
@@ -165,10 +165,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
         .then(function() {
           var docs = searcher.docs;
           expect(docs.length === 2);
-          expect(docs[0].field).toEqual(mockES4Results.hits.hits[0].fields.field[0]);
-          expect(docs[0].field1).toEqual(mockES4Results.hits.hits[0].fields.field1[0]);
-          expect(docs[1].field).toEqual(mockES4Results.hits.hits[1].fields.field[0]);
-          expect(docs[1].field1).toEqual(mockES4Results.hits.hits[1].fields.field1[0]);
+          expect(docs[0].field).toEqual(mockES4Results.hits.hits[0]._source.field[0]);
+          expect(docs[0].field1).toEqual(mockES4Results.hits.hits[0]._source.field1[0]);
+          expect(docs[1].field).toEqual(mockES4Results.hits.hits[1]._source.field[0]);
+          expect(docs[1].field1).toEqual(mockES4Results.hits.hits[1]._source.field1[0]);
           called++;
         });
 
@@ -283,10 +283,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
         .then(function() {
           var docs = searcher.docs;
           expect(docs.length === 2);
-          expect(docs[0].field).toEqual(mockES4Results.hits.hits[0].fields.field[0]);
-          expect(docs[0].field1).toEqual(mockES4Results.hits.hits[0].fields.field1[0]);
-          expect(docs[1].field).toEqual(mockES4Results.hits.hits[1].fields.field[0]);
-          expect(docs[1].field1).toEqual(mockES4Results.hits.hits[1].fields.field1[0]);
+          expect(docs[0].field).toEqual(mockES4Results.hits.hits[0]._source.field[0]);
+          expect(docs[0].field1).toEqual(mockES4Results.hits.hits[0]._source.field1[0]);
+          expect(docs[1].field).toEqual(mockES4Results.hits.hits[1]._source.field[0]);
+          expect(docs[1].field1).toEqual(mockES4Results.hits.hits[1]._source.field1[0]);
           called++;
         });
 
@@ -365,10 +365,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
 
           var firstHit  = mockES5Results.hits.hits[0];
           var secondHit = mockES5Results.hits.hits[1];
-          expect(docs[0].field).toEqual(firstHit.stored_fields.field[0]);
-          expect(docs[0].field1).toEqual(firstHit.stored_fields.field1[0]);
-          expect(docs[1].field).toEqual(secondHit.stored_fields.field[0]);
-          expect(docs[1].field1).toEqual(secondHit.stored_fields.field1[0]);
+          expect(docs[0].field).toEqual(firstHit._source.field[0]);
+          expect(docs[0].field1).toEqual(firstHit._source.field1[0]);
+          expect(docs[1].field).toEqual(secondHit._source.field[0]);
+          expect(docs[1].field1).toEqual(secondHit._source.field1[0]);
           called++;
         });
 
@@ -486,10 +486,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
 
           var firstHit  = mockES5Results.hits.hits[0];
           var secondHit = mockES5Results.hits.hits[1];
-          expect(docs[0].field).toEqual(firstHit.stored_fields.field[0]);
-          expect(docs[0].field1).toEqual(firstHit.stored_fields.field1[0]);
-          expect(docs[1].field).toEqual(secondHit.stored_fields.field[0]);
-          expect(docs[1].field1).toEqual(secondHit.stored_fields.field1[0]);
+          expect(docs[0].field).toEqual(firstHit._source.field[0]);
+          expect(docs[0].field1).toEqual(firstHit._source.field1[0]);
+          expect(docs[1].field).toEqual(secondHit._source.field[0]);
+          expect(docs[1].field1).toEqual(secondHit._source.field1[0]);
           called++;
         });
 
@@ -1316,18 +1316,16 @@ describe('Service: searchSvc: ElasticSearch', function() {
       );
     }));
 
-    it('defaults to version 5.0 and uses the "stored_fields" & "_source" params', function() {
+    it('defaults to version 5.0 and uses the "_source" params', function() {
       expect(searcher.config.version).toEqual('5.0');
 
       var expectedParams = {
-        stored_fields: mockFieldSpec.fieldList().join(','),
         _source:       mockFieldSpec.fieldList().join(',')
       };
 
       $httpBackend.when('POST', mockEsUrl,
         function(postData) {
           var jsonData = JSON.parse(postData);
-          expect(jsonData.stored_fields).toBe(expectedParams.stored_fields);
           expect(jsonData._source).toBe(expectedParams._source);
           return true;
         }


### PR DESCRIPTION
This PR removes several switches on ES version by relying on `_source` instead of `fields` / `stored_fields`. 

Required to get Splainer to support ES 2 and 5.