### PR TITLE
Adding support for Solr Json queries

### DIFF
--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -118,18 +118,10 @@
       }
 
       if (apiMethod === 'get' ) {
-        var fieldList = self.fieldList.join(',');
-
-        if ( 5 <= self.majorVersion() ) {
-          /*jshint camelcase: false */
-          esUrlSvc.setParams(uri, {
-            _source:       fieldList,
-          });
-        } else {
-          esUrlSvc.setParams(uri, {
-            _source: fieldList,
-          });
-        }
+        /*jshint camelcase: false */
+        esUrlSvc.setParams(uri, {
+          _source:       self.fieldList.join(','),
+        });
       }
 
       var url       = esUrlSvc.buildUrl(uri);

--- a/services/solrSearcherPreprocessorSvc.js
+++ b/services/solrSearcherPreprocessorSvc.js
@@ -40,12 +40,23 @@ angular.module('o19s.splainer-search')
           args['hl.simple.post']  = [searcher.HIGHLIGHTING_POST];
         }
 
+        if ( !args.rows ) {
+          args.rows = [config.numberOfRows];
+        }
+
         if (config.escapeQuery) {
           queryText = solrUrlSvc.escapeUserQuery(queryText);
         }
 
-        if ( !args.rows ) {
-          args.rows = [config.numberOfRows];
+        if (config.apiMethod === 'json') {
+          // We have a couple of options here:
+          //  - Do a POST with JSON body that is not jsonp;
+          //  - Do a GET with JSON body - not sure if it will work with jsonp;
+          //  - Do a GET with json request parameter in the query string;
+          //
+          // For simplicity sake, we are going with the latter.
+          args.json = queryText;
+          queryText = null;
         }
 
         var baseUrl = solrUrlSvc.buildUrl(url, args);

--- a/values/defaultSolrConfig.js
+++ b/values/defaultSolrConfig.js
@@ -5,6 +5,7 @@ angular.module('o19s.splainer-search')
     sanitize:     true,
     highlight:    true,
     debug:        true,
+    escapeQuery:  true,
     numberOfRows: 10,
-    escapeQuery:  true
+    apiMethod:    'querystring',
   });


### PR DESCRIPTION
This MRs brings basic Solr Json query support to splainer-search.

To pull this off, given the current codebase, we have the following options:
  - Do a POST with JSON body that is not jsonp (https://stackoverflow.com/a/4508215)
  - Do a GET with JSON body - not sure if it will work with jsonp;
  - Preserve the current way of doing things, and do a GET with json request parameter in the query string (see https://lucene.apache.org/solr/guide/8_1/json-request-api.html#building-json-requests)

For simplicity sake, we are going with the latter in this PR.

I wasn't able to test this - would love your help with testing and validating the solution.