### PR TITLE
Return explDict in consistent format

### DIFF
--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -312,12 +312,7 @@
 
       return $http.post(url, { query: self.queryDsl.query }, {headers: headers})
         .then(function(response) {
-          var explDict  = {
-            match:        response.data.matched,
-            explanation:  response.data.explanation,
-            description:  response.data.explanation.description,
-            value:        response.data.explanation.value,
-          };
+          var explDict  = response.data.explanation || null;
 
           var options = {
             fieldList: self.fieldList,

--- a/splainer-search.js
+++ b/splainer-search.js
@@ -2769,12 +2769,7 @@ angular.module('o19s.splainer-search')
 
       return $http.post(url, { query: self.queryDsl.query }, {headers: headers})
         .then(function(response) {
-          var explDict  = {
-            match:        response.data.matched,
-            explanation:  response.data.explanation,
-            description:  response.data.explanation.description,
-            value:        response.data.explanation.value,
-          };
+          var explDict  = response.data.explanation || null;
 
           var options = {
             fieldList: self.fieldList,


### PR DESCRIPTION
When parsing explains from a call to _search, explDict is set to the explanation JSON object (see: https://github.com/o19s/splainer-search/blob/master/factories/esSearcherFactory.js#L218).  For the "other" approach, a new object is created with the explanation nested as another property. (see: https://github.com/o19s/splainer-search/blob/master/factories/esSearcherFactory.js#L315)

As far as I can tell nothing is making using of the object structure returned by explainOther and no tests are broken.  If we're worried about breaking things we can modify https://github.com/o19s/splainer-search/blob/master/factories/esDocFactory.js#L55 to check for the different structure and return the nested explain if necessary.  Ultimately we probably want all methods of explain setting explDict to a consistent format.

This change fixes https://github.com/o19s/quepid/issues/25