### PR TITLE
Support "media" fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Version numbers correspond to `package.json` version
 # 2.5.6 ???
+- Support extracting media fields that have fieldspec media:
 
 # 2.5.5
 - This time with the `splainer-search.js` file!

--- a/services/fieldSpecSvc.js
+++ b/services/fieldSpecSvc.js
@@ -15,6 +15,13 @@ angular.module('o19s.splainer-search')
           fieldName = fieldName + ':$' + fieldName;
           fieldSpec.functions.push(fieldName);
         }
+        if (fieldType === 'media') {
+            if (!fieldSpec.hasOwnProperty('embeds')) {
+              fieldSpec.embeds = [];
+            }
+
+            fieldSpec.embeds.push(fieldName);
+        }
         if (fieldType === 'sub') {
           if (!fieldSpec.hasOwnProperty('subs')) {
             fieldSpec.subs = [];
@@ -98,6 +105,9 @@ angular.module('o19s.splainer-search')
           if (this.hasOwnProperty('thumb')) {
             innerBody(this.thumb);
           }
+          angular.forEach(this.embeds, function(embed) {
+            innerBody(embed);
+          });
           angular.forEach(this.subs, function(sub) {
             innerBody(sub);
           });

--- a/services/normalDocSvc.js
+++ b/services/normalDocSvc.js
@@ -73,6 +73,12 @@ angular.module('o19s.splainer-search')
         return funcFieldQuery.split(':')[0];
       };
 
+      var assignEmbeds = function(normalDoc, doc, fieldSpec) {
+        angular.forEach(fieldSpec.embeds, function (embedField) {
+            normalDoc.embeds[embedField] = doc[embedField];
+        });
+      };
+
       var assignSubs = function(normalDoc, doc, fieldSpec) {
         var parseValue = function(value) {
           if ( typeof value === 'object' ) {
@@ -120,6 +126,8 @@ angular.module('o19s.splainer-search')
         assignSingleField(normalDoc, doc, fieldSpec.id, 'id');
         assignSingleField(normalDoc, doc, fieldSpec.title, 'title');
         assignSingleField(normalDoc, doc, fieldSpec.thumb, 'thumb');
+        normalDoc.embeds = {};
+        assignEmbeds(normalDoc, doc, fieldSpec);
         normalDoc.subs = {};
         assignSubs(normalDoc, doc, fieldSpec);
       };

--- a/test/spec/fieldSpecSvc.js
+++ b/test/spec/fieldSpecSvc.js
@@ -54,13 +54,24 @@ describe('Service: fieldSpecSvc', function () {
     expect(fieldSpec.subs).toContain('subfield2');
   });
 
+  it('extracts media fields', function() {
+    var fieldSpec = fieldSpecSvc.createFieldSpec('id:foo_id atitlefield subfield1 subfield2 id:foo_id media:media1 media:media2');
+    expect(fieldSpec.id).toEqual('foo_id');
+    expect(fieldSpec.embeds).toContain('media1');
+    expect(fieldSpec.embeds).toContain('media2');
+    expect(fieldSpec.title).toEqual('atitlefield');
+    expect(fieldSpec.subs).toContain('subfield1');
+    expect(fieldSpec.subs).toContain('subfield2');
+  });
+
   it('gets plain field list', function() {
-    var fieldSpec = fieldSpecSvc.createFieldSpec('id:foo_id atitlefield subfield1 subfield2 id:foo_id thumb:foo_img');
+    var fieldSpec = fieldSpecSvc.createFieldSpec('id:foo_id atitlefield subfield1 subfield2 id:foo_id thumb:foo_img media:media1');
     expect(fieldSpec.fields).toContain('foo_id');
     expect(fieldSpec.fields).toContain('atitlefield');
     expect(fieldSpec.fields).toContain('subfield1');
     expect(fieldSpec.fields).toContain('subfield2');
     expect(fieldSpec.fields).toContain('foo_img');
+    expect(fieldSpec.fields).toContain('media1');
   });
 
   it('fields has id when no id specified', function() {


### PR DESCRIPTION
Allows fieldSpec to support "media:" fields which will be stored out to `embeds` within a doc.  

Supports https://github.com/o19s/quepid/issues/56