### PR TITLE
Don't include username+password in URL

### DIFF
--- a/services/esUrlSvc.js
+++ b/services/esUrlSvc.js
@@ -132,9 +132,6 @@ angular.module('o19s.splainer-search')
 
       function buildBaseUrl (uri) {
         var url = uri.protocol + '://';
-        if (uri.password && uri.username) {
-          url += uri.username + ':' + uri.password + '@';
-        }
         url += (uri.host);
 
         return url;

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -8,6 +8,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
 
   var searcher;
   var searchSvc;
+  var esUrlSvc;
   var $httpBackend;
   var fieldSpecSvc  = null;
   var mockEsUrl     = 'http://localhost:9200/statedecoded/_search';
@@ -34,9 +35,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
     $httpBackend = $injector.get('$httpBackend');
   }));
 
-  beforeEach(inject(function (_searchSvc_, _fieldSpecSvc_) {
+  beforeEach(inject(function (_searchSvc_, _fieldSpecSvc_, _esUrlSvc_) {
     searchSvc     = _searchSvc_;
     fieldSpecSvc  = _fieldSpecSvc_;
+    esUrlSvc = _esUrlSvc_;
     mockFieldSpec = fieldSpecSvc.createFieldSpec('field field1');
   }));
 
@@ -304,7 +306,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
           'es'
         );
 
-        $httpBackend.expectPOST(authEsUrl, undefined, function(headers) {
+        // The headers need to be removed from the URL, which we accomplish
+        // using the esUrlSvc.
+        var targetUrl = esUrlSvc.buildUrl(esUrlSvc.parseUrl(authEsUrl))
+        $httpBackend.expectPOST(targetUrl, undefined, function(headers) {
           return headers['Authorization'] == 'Basic ' + btoa('username:password');
         }).
         respond(200, mockES4Results);
@@ -504,7 +509,10 @@ describe('Service: searchSvc: ElasticSearch', function() {
           'es'
         );
 
-        $httpBackend.expectPOST(authEsUrl, undefined, function(headers) {
+        // The headers need to be removed from the URL, which we accomplish
+        // using the esUrlSvc.
+        var targetUrl = esUrlSvc.buildUrl(esUrlSvc.parseUrl(authEsUrl))
+        $httpBackend.expectPOST(targetUrl, undefined, function(headers) {
           return headers['Authorization'] == 'Basic ' + btoa('username:password');
         }).
         respond(200, mockES5Results);

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -60,12 +60,6 @@ describe('Service: esUrlSvc', function () {
       expect(uri.username).toBe('username');
       expect(uri.password).toBe('password');
 
-      var rebuiltUri = esUrlSvc.buildUrl(uri);
-      var uriAgain = esUrlSvc.parseUrl(rebuiltUri);
-
-      expect(uriAgain.username).toBe('username');
-      expect(uriAgain.password).toBe('password');
-
     });
 
     it('understands when bulk endpoint used', function() {


### PR DESCRIPTION
Including the `user:pass@` in the XHR causes Firefox to block the request, despite proper CORS settings being set. The search service already sets the proper `Authorization` header, so it isn't necessary to include it in the URL anyways.