### PR TITLE
Highlighting fails on fields that are dates or integers

### DIFF
--- a/services/solrSearcherPreprocessorSvc.js
+++ b/services/solrSearcherPreprocessorSvc.js
@@ -35,6 +35,7 @@ angular.module('o19s.splainer-search')
 
         if (config.highlight) {
           args.hl                 = ['true'];
+          args['hl.method']       = ['unified'];  // work around issues parsing dates and numbers
           args['hl.fl']           = args.fl;
           args['hl.simple.pre']   = [searcher.HIGHLIGHTING_PRE];
           args['hl.simple.post']  = [searcher.HIGHLIGHTING_POST];


### PR DESCRIPTION
this may fix o19s/quepid#84.   It appears that `hl.method=unified` deals with dates, and having it hard coded in the URL doesn't impact Solr 4, which didn't have it as an option.