### PR TITLE
WIP: Introduce seperate highlight fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Version numbers correspond to `package.json` version
 
+# 2.6.0 (??)
+- We've fought with highlighting fields for many years, as that was a core concept from the beginning that you would highlight everything.  Lets not use our fieldList as our highlighting fields as well, and instead we now have support for a separate list of fields for highlighting.  We can then be smart and not attempt to highlight functions for example.  Or open the door to having Splainer.io and Quepid users set their own preferred list of highlighted fields!  https://github.com/o19s/splainer-search/pull/85
+
 # 2.5.9 (04/27/2020)
 - Highlighting on dates and integers in Solr causes an error.  Work around is to append `hl.method=unified` to calls to Solr.  https://github.com/o19s/splainer-search/pull/84
 - a common pattern in Solr schemas is to normalize fields with dots: `foo.bar`, however if you have a array or dictionary of JSON, we want to navigate that.  Now we check if the key exists with a dot in it, if not, we use that as a selector to pluck out the data in the nested JSON that we need.  https://github.com/o19s/splainer-search/pull/83

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ Splainer search utilizes a JSONP wrapper for communication with Solr. Elasticsea
 
 ### Solr
 
-Splainer-search will perform the specified search against Solr attempting to highlight and extract explain info.
+Splainer-search will perform the specified search against Solr attempting to highlight the title and body fields and extract explain info.
 
 ```js
 // searcher that searches id, title, body, author
 var searcher = searchSvc.createSearcher(
   ['id', 'title', 'body', 'author'],
+  ['title', 'body'],
   'http://localhost:8983/solr/select',
   {
     'q': ['*:*'],
@@ -46,6 +47,7 @@ Splainer-search also supports ES, using the same API, and passing the query DSL 
 ```js
 var searcher = searchSvc.createSearcher(
   ['id:_id', 'title', 'body', 'author'],
+  ['title', 'body'],
   'http://localhost:9200/books/_search',
   {
     'query': {
@@ -98,13 +100,14 @@ So assuming you already have something like this:
 ```js
 var options = {
   fields:       ['id', 'title', 'price'],
+  highlightFields: ['title'],
   url:          'http://localhost:8983/solr/select',
   args:         { 'q': ['#$query##'] },
   query:        'tacos',
   config:       {},
   searchEngine: 'solr'
 };
-var searcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine);
+var searcher = searchSvc.createSearcher(options.fields, options.highlightFields, options.url, options.args, options.query, options.config, options.searchEngine);
 
 searcher.search();
 ```
@@ -113,7 +116,7 @@ You would want to create a new searcher with the same options/context, and use t
 
 ```js
 var fieldSpec       = fieldSpecSvc.createFieldSpec(options.fields);
-var explainSearcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine); # same options as above
+var explainSearcher = searchSvc.createSearcher(options.fields, options.highlightFields, options.url, options.args, options.query, options.config, options.searchEngine); # same options as above
 
  # assuming that we know "El Bomba" has id 63148
 explainSearcher.explainOther('id:63148', fieldSpec);
@@ -128,6 +131,7 @@ In ES, the `explainOther()` function behaves the same way, except that it does n
 ```js
 var options = {
   fields:       ['id', 'title', 'price'],
+  highlightFields: ['title'],
   url:          'http://localhost:9200/tacos/_search',
   args:         {
     'query': {
@@ -140,11 +144,11 @@ var options = {
   config:       {},
   searchEngine: 'es'
 };
-var searcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine);
+var searcher = searchSvc.createSearcher(options.fields, options.highlightFields, options.url, options.args, options.query, options.config, options.searchEngine);
 
 searcher.search();
 
-var explainSearcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine); # same options as above
+var explainSearcher = searchSvc.createSearcher(options.fields, options.highlightFields, options.url, options.args, options.query, options.config, options.searchEngine); # same options as above
 
  # assuming that we know "El Bomba" has id 63148
 explainSearcher.explainOther('id:63148');
@@ -163,6 +167,7 @@ var userFieldSpec = "id:uuid, title, body, authors"
 var fs = fieldSpecSvc.createFieldSpec(userFieldSpec)
 var searcher = searchSvc.createSearcher(
   fs.fieldList(),
+  fs.highlightFieldList(),
   'http://localhost:8983/solr/select',
   {
     'q': ['*:*'],
@@ -219,6 +224,7 @@ To do so you only need to specify the version number in the `config` param when 
 ```js
 var options = {
   fields:       ['id', 'title', 'price'],
+  highlightFields: ['title'],
   url:          'http://localhost:9200/tacos/_search',
   args:         {
     'query': {
@@ -231,7 +237,7 @@ var options = {
   config:       { version: 5.1 },
   searchEngine: 'es'
 };
-var searcher = searchSvc.createSearcher(options.fields, options.url, options.args, options.query, options.config, options.searchEngine);
+var searcher = searchSvc.createSearcher(options.fields, options.highlightFields, options.url, options.args, options.query, options.config, options.searchEngine);
 
 searcher.search();
 ```
@@ -294,3 +300,7 @@ np
 Development for this library is done primarily by [OpenSource Connections](http://opensourceconnections.com) for search relevance tools [Splainer](http://splainer.io) and [Quepid](http://quepid.com)
 
 Primary author is [Doug Turnbull](http://softwaredoug.com)
+
+Todos: Test with "score"
+Todos: Check line 120 of esSearcherFactory for ES 5 support, I think we've lost/droppped that backwards compatiblity. Maybe just itme to ditch pre ES5?
+Todos: check if ./pages folder needed.

--- a/README.md
+++ b/README.md
@@ -304,3 +304,4 @@ Primary author is [Doug Turnbull](http://softwaredoug.com)
 Todos: Test with "score"
 Todos: Check line 120 of esSearcherFactory for ES 5 support, I think we've lost/droppped that backwards compatiblity. Maybe just itme to ditch pre ES5?
 Todos: check if ./pages folder needed.
+Todos: see if method createSearcherFromSettings on searchSvc.js is actually used!

--- a/README.md
+++ b/README.md
@@ -305,3 +305,58 @@ Todos: Test with "score"
 Todos: Check line 120 of esSearcherFactory for ES 5 support, I think we've lost/droppped that backwards compatiblity. Maybe just itme to ditch pre ES5?
 Todos: check if ./pages folder needed.
 Todos: see if method createSearcherFromSettings on searchSvc.js is actually used!
+
+
+
+## ARGH.  What to do???
+
+I am stuck at the intersection of highlighting and not, and almost thinking there isn't a good "rules engine" approach.
+
+Sample Solr Doc
+
+```
+{
+  "id": "doc1",
+  "title": "star wars rocks",
+  "overview": ["in a galaxy a long way away"],
+  "actors": ["Harrison Ford", "John Ford", "Carrie Fisher"],
+  "foo.bar": "hi there, mr. fubar",
+  "actor": {
+    "first_name": "Bob",
+    "last_name": "Hope"
+  },
+  "genres":[
+    {
+      "id": 1,
+      "name": "action"
+    },
+    {
+      "id": 2,
+      "name": "comedy"
+    }
+  ]
+}
+```
+
+So, here is `fl=id,title,overview&q=galaxy`
+  => fl = overview    -> in a galaxy a long way away
+  => hl = overview    -> in a <em>galaxy</em> a long way away
+
+  So, here is `fl=id,title,overview,f:myfunc&q=galaxy`
+    => fl = overview    -> in a galaxy a long way away
+            f:myfunc    -> value of myfunc
+    => hl = overview    -> in a <em>galaxy</em> a long way away
+
+So, here is `fl=id,title,overview,foo.bar&q=galaxy OR fubar`
+  => fl = overview,foo.bar
+  => hl = overview    -> in a <em>galaxy</em> a long way away
+          foo.bar     -> hi there, mr. <em>fubar</em>
+
+So, here is `fl=id,title,actor.name&q=bob`
+  => fl = actor.name  -> Bob
+  => hl = actor.name  -> <em>Bob</em>
+
+So, here is `fl=id,title,actor.name, genre.name&q=bob  OR comedy`
+  => fl = actor.name  -> Bob, genre.name  -> Action,Comedy
+  => hl = actor.name  -> <em>Bob</em>
+          genre.name  -> <em>Comedy</em>    <-- Is this waht we want???

--- a/factories/resolverFactory.js
+++ b/factories/resolverFactory.js
@@ -69,6 +69,7 @@
 
       self.searcher = searchSvc.createSearcher(
         self.fieldSpec.fieldList(),
+        self.fieldSpec.highlightFieldList(),
         self.settings.searchUrl,
         self.args,
         self.queryText,

--- a/factories/searcherFactory.js
+++ b/factories/searcherFactory.js
@@ -11,6 +11,7 @@
       var self                = this;
 
       self.fieldList          = options.fieldList;
+      self.highlightFieldList = options.highlightFieldList;
       self.url                = options.url;
       self.args               = options.args;
       self.queryText          = options.queryText;

--- a/factories/settingsValidatorFactory.js
+++ b/factories/settingsValidatorFactory.js
@@ -19,6 +19,7 @@
 
       self.searcher = null;
       self.fields   = [];
+      self.highlightFields = [];
       self.idFields = [];
 
       self.setupSearcher  = setupSearcher;
@@ -29,6 +30,7 @@
       function setupSearcher () {
         var args    = { };
         var fields  = '*';
+        var highlightFields = '';
 
         if ( self.searchEngine === 'solr' ) {
           args = { q: ['*:*'] };
@@ -38,6 +40,7 @@
 
         self.searcher = searchSvc.createSearcher(
           fields,
+          highlightFields,
           self.searchUrl,
           args,
           '',

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -89,6 +89,7 @@
 
       var options = {
         fieldList:          self.fieldList,
+        highlightFieldList: self.highlightFieldList,
         url:                self.url,
         args:               nextArgs,
         queryText:          self.queryText,
@@ -157,6 +158,7 @@
                 groupedBy:          groupedBy,
                 group:              group,
                 fieldList:          self.fieldList,
+                highlightFieldList: self.highlightFieldList,
                 url:                self.url,
                 explDict:           explDict,
                 hlDict:             hlDict,
@@ -242,6 +244,7 @@
 
           var otherSearcherOptions = {
             fieldList:          self.fieldList,
+            highlightFieldList: self.highlightFieldList,
             url:                self.url,
             args:               solrParams,
             queryText:          otherQuery,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "splainer-search",
-  "version": "2.5.9-0",
+  "version": "2.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "splainer-search",
-  "version": "2.5.9",
+  "version": "2.6.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splainer-search",
-  "version": "2.5.9",
+  "version": "2.6.0-0",
   "main": "splainer-search.js",
   "authors": [
     "Doug Turnbull <dturnbull@opensourceconnections.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splainer-search",
-  "version": "2.5.9-0",
+  "version": "2.5.9",
   "main": "splainer-search.js",
   "authors": [
     "Doug Turnbull <dturnbull@opensourceconnections.com>",

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -79,8 +79,8 @@ angular.module('o19s.splainer-search')
         }
 
         if ( !queryDsl.hasOwnProperty('highlight') ) {
-          queryDsl.highlight = prepareHighlighting(searcher.args, queryDsl[self.fieldsParamNames[0]]);
-          //queryDsl.highlight = prepareHighlighting(searcher.args, searcher.highlightFieldList;
+          //queryDsl.highlight = prepareHighlighting(searcher.args, queryDsl[self.fieldsParamNames[0]]);
+          queryDsl.highlight = prepareHighlighting(searcher.args, searcher.highlightFieldList);
           console.log("Here is our highlights::");
           console.log(queryDsl.highlight);
         }

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -29,6 +29,9 @@ angular.module('o19s.splainer-search')
       };
 
       var prepareHighlighting = function (args, fields) {
+        console.log("prepareHighlighting");
+        console.log(args);
+        console.log(fields);
         if ( angular.isDefined(fields) && fields !== null ) {
           if ( fields.hasOwnProperty('fields') ) {
             fields = fields.fields;
@@ -77,6 +80,9 @@ angular.module('o19s.splainer-search')
 
         if ( !queryDsl.hasOwnProperty('highlight') ) {
           queryDsl.highlight = prepareHighlighting(searcher.args, queryDsl[self.fieldsParamNames[0]]);
+          //queryDsl.highlight = prepareHighlighting(searcher.args, searcher.highlightFieldList;
+          console.log("Here is our highlights::");
+          console.log(queryDsl.highlight);
         }
 
         searcher.queryDsl   = queryDsl;

--- a/services/fieldSpecSvc.js
+++ b/services/fieldSpecSvc.js
@@ -97,6 +97,17 @@ angular.module('o19s.splainer-search')
           return rVal;
         };
 
+        this.highlightFieldList = function() {
+          if (this.hasOwnProperty('subs') && this.subs === '*') {
+            return '*';
+          }
+          var rVal = [];
+          this.forEachHighlightableField(function(fieldName) {
+            rVal.push(fieldName);
+          });
+          return rVal;
+        };
+
         // Execute innerBody for each (non id) field
         this.forEachField = function(innerBody) {
           if (this.hasOwnProperty('title')) {
@@ -115,7 +126,30 @@ angular.module('o19s.splainer-search')
             innerBody(func);
           });
         };
+
+        // Execute innerBody for each (non id) field
+        this.forEachHighlightableField = function(innerBody) {
+          console.log("hi");
+          console.log(this);
+          if (this.hasOwnProperty('title')) {
+            innerBody(this.title);
+          }
+          if (this.hasOwnProperty('thumb')) {
+            //innerBody(this.thumb);
+          }
+          angular.forEach(this.embeds, function(embed) {
+            //innerBody(embed);
+          });
+          angular.forEach(this.subs, function(sub) {
+            innerBody(sub);
+          });
+          angular.forEach(this.functions, function(func) {
+            //innerBody(func);
+          });
+        };
+
       };
+
 
       var transformFieldSpec = function(fieldSpecStr) {
         var defFieldSpec = 'id:id title:id *';

--- a/services/searchSvc.js
+++ b/services/searchSvc.js
@@ -27,8 +27,11 @@ angular.module('o19s.splainer-search')
       };
 
       this.createSearcherFromSettings = function(settings, queryText, searchEngine) {
+        console.log("\n\n\nI WAS CALLED, AND NOT SURE I AM USED");
+        var fieldSpec = settings.createFieldSpec();
         return this.createSearcher(
-          settings.createFieldSpec().fieldList(),
+          fieldSpec.fieldList(),
+          fieldSpec.highlightFieldList(),
           settings.url,
           settings.selectedTry.args,
           queryText,

--- a/services/searchSvc.js
+++ b/services/searchSvc.js
@@ -39,13 +39,14 @@ angular.module('o19s.splainer-search')
         );
       };
 
-      this.createSearcher = function (fieldList, url, args, queryText, config, searchEngine) {
+      this.createSearcher = function (fieldList, highlightFieldList, url, args, queryText, config, searchEngine) {
         if ( searchEngine === undefined ) {
           searchEngine = 'solr';
         }
 
         var options = {
           fieldList:      fieldList,
+          highlightFieldList: highlightFieldList,
           url:            url,
           args:           args,
           queryText:      queryText,
@@ -61,6 +62,7 @@ angular.module('o19s.splainer-search')
 
           searcher = new SolrSearcherFactory(options);
         } else if ( searchEngine === 'es') {
+          console.log("Calling ESSearcherFactory");
           searcher = new EsSearcherFactory(options);
         }
 

--- a/services/solrSearcherPreprocessorSvc.js
+++ b/services/solrSearcherPreprocessorSvc.js
@@ -20,6 +20,7 @@ angular.module('o19s.splainer-search')
       // the full URL we'll use to call Solr
       var buildCallUrl = function(searcher) {
         var fieldList = searcher.fieldList;
+        var highlightFieldList = searcher.highlightFieldList;
         var url       = searcher.url;
         var config    = searcher.config;
         var args      = withoutUnsupported(searcher.args, config.sanitize);
@@ -36,7 +37,8 @@ angular.module('o19s.splainer-search')
         if (config.highlight) {
           args.hl                 = ['true'];
           args['hl.method']       = ['unified'];  // work around issues parsing dates and numbers
-          args['hl.fl']           = args.fl;
+          console.log("We should be only including actual fields for highlihgting, not functions:" + args.highlightFieldList);
+          args['hl.fl']           = args.highlightFieldList;
           args['hl.simple.pre']   = [searcher.HIGHLIGHTING_PRE];
           args['hl.simple.post']  = [searcher.HIGHLIGHTING_POST];
         }

--- a/services/solrSearcherPreprocessorSvc.js
+++ b/services/solrSearcherPreprocessorSvc.js
@@ -37,8 +37,8 @@ angular.module('o19s.splainer-search')
         if (config.highlight) {
           args.hl                 = ['true'];
           args['hl.method']       = ['unified'];  // work around issues parsing dates and numbers
-          console.log("We should be only including actual fields for highlihgting, not functions:" + args.highlightFieldList);
-          args['hl.fl']           = args.highlightFieldList;
+          console.log("We should be only including actual fields for highlihgting, not functions:" + highlightFieldList);
+          args['hl.fl']           = highlightFieldList;
           args['hl.simple.pre']   = [searcher.HIGHLIGHTING_PRE];
           args['hl.simple.post']  = [searcher.HIGHLIGHTING_POST];
         }

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -634,7 +634,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
       mockEsUrl     = 'http://localhost:9200/tmdb/_search';
 
       searcher = searchSvc.createSearcher(
-        mockFieldSpec,
+        mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -709,7 +710,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
       mockFieldSpec = fieldSpecSvc.createFieldSpec('id:_id title');
 
       searcher = searchSvc.createSearcher(
-        mockFieldSpec,
+        mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -767,7 +769,6 @@ describe('Service: searchSvc: ElasticSearch', function() {
         var esQuery           = angular.fromJson(data);
         var expectedHighlight = {
           fields: {
-            _id:    { },
             title:  { },
           }
         };
@@ -786,7 +787,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
       mockFieldSpec = fieldSpecSvc.createFieldSpec('id:_id title section tags');
 
       searcher = searchSvc.createSearcher(
-        mockFieldSpec,
+        mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -798,7 +800,6 @@ describe('Service: searchSvc: ElasticSearch', function() {
         var esQuery           = angular.fromJson(data);
         var expectedHighlight = {
           fields: {
-            _id:      { },
             title:    { },
             section:  { },
             tags:     { },
@@ -957,7 +958,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       };
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
-
+        mockFieldSpec.highlightFieldList,
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -1083,7 +1084,6 @@ describe('Service: searchSvc: ElasticSearch', function() {
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
         mockFieldSpec.highlightFieldList(),
-        mockFieldSpec,
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -1140,7 +1140,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
 
     it('accounts for custom rows count', function() {
       searcher = searchSvc.createSearcher(
-        mockFieldSpec,
+        mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockEsUrl,
         mockEsParams,
         mockQueryText,

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -40,6 +40,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
     fieldSpecSvc  = _fieldSpecSvc_;
     esUrlSvc = _esUrlSvc_;
     mockFieldSpec = fieldSpecSvc.createFieldSpec('field field1');
+    console.log("Here is highlihgt fields" + mockFieldSpec.highlightFieldList());
   }));
 
   var mockES4Results = {
@@ -137,6 +138,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       beforeEach(inject(function () {
         searcher = searchSvc.createSearcher(
           mockFieldSpec.fieldList,
+          mockFieldSpec.highlightFieldList,
           mockEsUrl,
           mockEsParams,
           mockQueryText,
@@ -160,6 +162,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       it('passes the rows param and sets it to what is passed in the config', function() {
         searcher = searchSvc.createSearcher(
           mockFieldSpec.fieldList,
+          mockFieldSpec.highlightFieldList,
           mockEsUrl,
           mockEsParams,
           mockQueryText,
@@ -299,6 +302,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
         var authEsUrl = 'http://username:password@localhost:9200/statedecoded/_search';
         searcher = searchSvc.createSearcher(
           mockFieldSpec.fieldList,
+          mockFieldSpec.highlightFieldList,
           authEsUrl,
           mockEsParams,
           mockQueryText,
@@ -337,6 +341,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       beforeEach(inject(function () {
         searcher = searchSvc.createSearcher(
           mockFieldSpec.fieldList,
+          mockFieldSpec.highlightFieldList,
           mockEsUrl,
           mockEsParams,
           mockQueryText,
@@ -360,6 +365,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       it('passes the rows param and sets it to what is passed in the config', function() {
         searcher = searchSvc.createSearcher(
           mockFieldSpec.fieldList,
+          mockFieldSpec.highlightFieldList,
           mockEsUrl,
           mockEsParams,
           mockQueryText,
@@ -502,6 +508,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
         var authEsUrl = 'http://username:password@localhost:9200/statedecoded/_search';
         searcher = searchSvc.createSearcher(
           mockFieldSpec.fieldList,
+          mockFieldSpec.highlightFieldList,
           authEsUrl,
           mockEsParams,
           mockQueryText,
@@ -544,6 +551,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
     beforeEach(inject(function () {
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
+        mockFieldSpec.highlightFieldList,
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -818,7 +826,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
       esParamsWithHl.highlight = expectedHighlight;
 
       searcher = searchSvc.createSearcher(
-        mockFieldSpec,
+        mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockEsUrl,
         esParamsWithHl,
         mockQueryText,
@@ -920,6 +929,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       };
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
+        mockFieldSpec.highlightFieldList,
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -947,6 +957,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       };
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
+
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -974,6 +985,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       };
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
+        mockFieldSpec.highlightFieldList,
         mockEsUrl,
         mockEsParams,
         null,
@@ -1001,6 +1013,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       };
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
+        mockFieldSpec.highlightFieldList,
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -1068,6 +1081,8 @@ describe('Service: searchSvc: ElasticSearch', function() {
       mockFieldSpec = fieldSpecSvc.createFieldSpec('id:_id title');
 
       searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockFieldSpec,
         mockEsUrl,
         mockEsParams,
@@ -1161,6 +1176,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
     beforeEach(inject(function () {
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
+        mockFieldSpec.highlightFieldList,
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -1213,6 +1229,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
     beforeEach(inject(function () {
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -1349,6 +1366,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
     beforeEach(inject(function () {
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList().join(','),
+        mockFieldSpec.highlightFieldList().join(','),
         mockEsUrl,
         mockEsParams,
         mockQueryText,
@@ -1381,6 +1399,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
     beforeEach(inject(function () {
       searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList,
+        mockFieldSpec.highlightFieldList,
         mockEsUrl,
         mockEsParams,
         mockQueryText,

--- a/test/spec/fieldSpecSvc.js
+++ b/test/spec/fieldSpecSvc.js
@@ -117,6 +117,7 @@ describe('Service: fieldSpecSvc', function () {
     var fieldSpec = fieldSpecSvc.createFieldSpec('id:foo_id, atitlefield, *');
     expect(fieldSpec.subs).toEqual('*');
     expect(fieldSpec.fieldList()).toEqual('*');
+    expect(fieldSpec.highlightFieldList()).toEqual('*');
   });
 
   it('correctly transforms *', function() {
@@ -133,6 +134,7 @@ describe('Service: fieldSpecSvc', function () {
     expect(fieldSpec.id).toEqual('id');
     expect(fieldSpec.title).toEqual('id');
     expect(fieldSpec.fieldList()).toEqual('*');
+    expect(fieldSpec.highlightFieldList()).toEqual('*');
   });
 
   it('correctly transforms empty', function() {
@@ -141,6 +143,7 @@ describe('Service: fieldSpecSvc', function () {
     expect(fieldSpec.id).toEqual('id');
     expect(fieldSpec.title).toEqual('id');
     expect(fieldSpec.fieldList()).toEqual('*');
+    expect(fieldSpec.highlightFieldList()).toEqual('*');
   });
 
   it('preserves certain computed fields', function() {
@@ -177,9 +180,14 @@ describe('Service: fieldSpecSvc', function () {
     expect(fieldSpec.title).toEqual('catch_line');
 
     var fieldList = fieldSpec.fieldList();
+    var highlightFieldList = fieldSpec.highlightFieldList();
     expect(fieldList).toContain('someFunctionQuery:$someFunctionQuery');
     expect(fieldList).toContain('text');
     expect(fieldList).toContain('catch_line');
+    expect(highlightFieldList).not.toContain('someFunctionQuery:$someFunctionQuery');
+    expect(highlightFieldList).toContain('text');
+    expect(highlightFieldList).toContain('catch_line');
+
 
     fieldSpec = fieldList = undefined;
     fieldSpec = fieldSpecSvc.createFieldSpec('catch_line,text,f:someFunctionQuery');
@@ -197,20 +205,10 @@ describe('Service: fieldSpecSvc', function () {
   it('allows periods in a field name', function() {
     var fieldSpec = fieldSpecSvc.createFieldSpec('id:foo_id, foo.bar');
     var fieldList = fieldSpec.fieldList();
+    var highlightFieldList = fieldSpec.highlightFieldList();
     expect(fieldSpec.id).toEqual('foo_id');
     expect(fieldList).toContain('foo.bar');
-  });
-
-  it('respects escaping periods by wrapping in quotes', function() {
-    var fieldSpec = fieldSpecSvc.createFieldSpec('id:foo_id, "foo.bar"');
-    var fieldList = fieldSpec.fieldList();
-    expect(fieldSpec.id).toEqual('foo_id');
-    expect(fieldList).toContain('"foo.bar"');
-
-    fieldSpec = fieldSpecSvc.createFieldSpec("id:foo_id, 'foo.bar'");
-    fieldList = fieldSpec.fieldList();
-    expect(fieldSpec.id).toEqual('foo_id');
-    expect(fieldList).toContain("'foo.bar'");
+    expect(highlightFieldList).toContain('foo.bar');
   });
 
 });

--- a/test/spec/normalDocSvc.js
+++ b/test/spec/normalDocSvc.js
@@ -122,7 +122,7 @@ describe('Service: normalDocsSvc', function () {
       expect(snips.another_field).toEqual('<b>' + availableHighlight + '</b>');
     });
 
-    it('uses highlights for sub fileds', function() {
+    it('uses highlights for sub fields', function() {
       availableHighlight = 'something';
       var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: ['another_field']};
       var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
@@ -369,6 +369,23 @@ describe('Service: normalDocsSvc', function () {
 
       expect(normalDoc.subSnippets('<b>', '</b>').sub1).toEqual('<b>sub1_hl</b>');
       expect(normalDoc.subSnippets('<b>', '</b>').sub2).toEqual('sub2_val');
+    });
+
+    it('captures sub values w/ highlight with multivalued field', function() {
+      solrDoc['overview'] = ["overview in multivalued field","blah"]
+
+      var fieldSpec = {id: 'custom_id_field', title: 'title_field', subs: '*'};
+      availableHighlights.sub1 = 'sub1_hl';
+      availableHighlights.overview = 'overview in multivalued field';
+      var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, solrDoc);
+      expect(Object.keys(normalDoc.subs).length).toEqual(4);
+      expect(normalDoc.subs.sub1).toEqual('sub1_val');
+      expect(normalDoc.subs.sub2).toEqual('sub2_val');
+      expect(normalDoc.subs.fn).toEqual('2');
+
+      expect(normalDoc.subSnippets('<b>', '</b>').sub1).toEqual('<b>sub1_hl</b>');
+      expect(normalDoc.subSnippets('<b>', '</b>').sub2).toEqual('sub2_val');
+      expect(normalDoc.subSnippets('<b>', '</b>').overview).toEqual('overview in multivalued field');
     });
 
   });

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -102,8 +102,9 @@ describe('Service: searchSvc: Solr', function () {
 
     var createSearcherHlOn = function() {
       var fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
+      console.log("\n\n\nHEre is higlihgt" + fieldSpec.highlightFieldList());
       searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
-                                                  mockSolrParams, mockQueryText);
+                                                  mockSolrParams, mockQueryText, {}, 'solr');
     };
 
     var createSearcherHlOff = function() {
@@ -112,7 +113,7 @@ describe('Service: searchSvc: Solr', function () {
       noHlConfig.highlight = false;
       searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText,
-                                                  noHlConfig);
+                                                  noHlConfig, 'solr');
     };
 
     var expectedHlParams = null;
@@ -133,7 +134,7 @@ describe('Service: searchSvc: Solr', function () {
       expectedHlParams = {'hl': ['true'],
                           'hl.simple.pre': [searchSvc.HIGHLIGHTING_PRE],
                           'hl.simple.post': [searchSvc.HIGHLIGHTING_POST],
-                          'hl.fl': ['path content']};
+                          'hl.fl': ['content']};
     });
 
     it('asks for highlights', function() {

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -44,7 +44,7 @@ describe('Service: searchSvc: Solr', function () {
   }));
 
   it('access solr with mock solr params', function() {
-    var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+    var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                 mockSolrParams, mockQueryText);
     $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                             .respond(200, mockResults);
@@ -55,7 +55,7 @@ describe('Service: searchSvc: Solr', function () {
 
   it('tracks active queries', function() {
     expect(searchSvc.activeQueries()).toEqual(0);
-    var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+    var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                 mockSolrParams, mockQueryText);
     $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                             .respond(200, mockResults);
@@ -102,7 +102,7 @@ describe('Service: searchSvc: Solr', function () {
 
     var createSearcherHlOn = function() {
       var fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
     };
 
@@ -110,7 +110,7 @@ describe('Service: searchSvc: Solr', function () {
       var fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
       var noHlConfig = searchSvc.configFromDefault();
       noHlConfig.highlight = false;
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText,
                                                   noHlConfig);
     };
@@ -356,7 +356,7 @@ describe('Service: searchSvc: Solr', function () {
 
     var createSearcherWithDebug = function() {
       fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
     };
 
@@ -364,7 +364,7 @@ describe('Service: searchSvc: Solr', function () {
       var fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
       var noHlConfig = searchSvc.configFromDefault();
       noHlConfig.debug = false;
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(),fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText,
                                                   noHlConfig);
     };
@@ -448,7 +448,7 @@ describe('Service: searchSvc: Solr', function () {
     var searcher = null;
     beforeEach(function() {
       fieldSpec = fieldSpecSvc.createFieldSpec('id:altId');
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
     });
 
@@ -494,7 +494,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParamsMm = angular.copy(expectedParams);
       mockSolrParamsWithMm.mm = ['100%25'];
       var fieldSpec = fieldSpecSvc.createFieldSpec('id:altId');
-      var searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParamsWithMm, mockQueryText);
       $httpBackend.expectJSONP(
         urlContainsParams(mockSolrUrl, expectedParamsMm)
@@ -518,6 +518,7 @@ describe('Service: searchSvc: Solr', function () {
     it('passes the rows param and sets it to 10 by default', function() {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -541,6 +542,7 @@ describe('Service: searchSvc: Solr', function () {
     it('passes the rows param and sets it to what is passed in the config', function() {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText,
@@ -565,6 +567,7 @@ describe('Service: searchSvc: Solr', function () {
     it('makes querydocs with tokensUrl', function() {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -588,7 +591,7 @@ describe('Service: searchSvc: Solr', function () {
     });
 
     it('escapes ids passed into url', function() {
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -609,6 +612,7 @@ describe('Service: searchSvc: Solr', function () {
       var fieldSpecWithScore = fieldSpecSvc.createFieldSpec('field field1 score');
       var searcher = searchSvc.createSearcher(
         fieldSpecWithScore.fieldList(),
+        fieldSpecWithScore.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -636,7 +640,7 @@ describe('Service: searchSvc: Solr', function () {
 
     it('linkurl has wt=xml', function() {
       var fieldSpecWithScore = fieldSpecSvc.createFieldSpec('field field1 score');
-      var searcher = searchSvc.createSearcher(fieldSpecWithScore.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(fieldSpecWithScore.fieldList(), fieldSpecWithScore.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       expect(searcher.linkUrl.indexOf('wt=xml')).not.toBe(-1);
     });
@@ -650,6 +654,7 @@ describe('Service: searchSvc: Solr', function () {
       mockUncleanSolrParams.debug = ['true'];
       var searcher = searchSvc.createSearcher(
         fieldSpecWithScore.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockUncleanSolrParams,
         mockQueryText
@@ -668,6 +673,7 @@ describe('Service: searchSvc: Solr', function () {
       mockUncleanSolrParams.rows = ['20'];
       var searcher = searchSvc.createSearcher(
         fieldSpecWithScore.fieldList(),
+        fieldSpecWithScore.highlightFieldList(),
         mockSolrUrl,
         mockUncleanSolrParams,
         mockQueryText,
@@ -682,8 +688,13 @@ describe('Service: searchSvc: Solr', function () {
 
     it('searches with fl == *', function() {
       var fieldSpec = fieldSpecSvc.createFieldSpec('*');
-      var searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
-                                                  {'q': ['*:*']}, mockQueryText);
+      var searcher = searchSvc.createSearcher(
+        fieldSpec.fieldList(),
+        fieldSpec.highlightFieldList(),
+        mockSolrUrl,
+        {'q': ['*:*']},
+        mockQueryText
+      );
       var testSolrParams = {'fl': ['*']};
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, testSolrParams))
                               .respond(200, mockResults);
@@ -701,6 +712,7 @@ describe('Service: searchSvc: Solr', function () {
 
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         queryWithSpecialChars
@@ -922,7 +934,7 @@ describe('Service: searchSvc: Solr', function () {
 
     beforeEach(function() {
       fieldSpec = fieldSpecSvc.createFieldSpec('id catch_line');
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                               mockSolrParams, mockQueryText);
     });
 
@@ -994,7 +1006,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = encodeURIComponent(mockQueryText);
 
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -1011,7 +1023,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco';
 
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -1028,7 +1040,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco nothing ""';
 
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -1045,7 +1057,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco nothing someDefault';
 
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -1062,7 +1074,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco nothing someDefault otherDefaults taco';
 
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -1079,7 +1091,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco nothing someDefault otherDefaults "" taco';
 
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -1096,7 +1108,7 @@ describe('Service: searchSvc: Solr', function () {
       var expectedParams = angular.copy(mockSolrParams);
       expectedParams.q[0] = 'burrito query taco nothing nacho';
 
-      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockSolrUrl,
+      var searcher = searchSvc.createSearcher(mockFieldSpec.fieldList(), mockFieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))
                               .respond(200, mockResults);
@@ -1122,6 +1134,7 @@ describe('Service: searchSvc: Solr', function () {
 
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -1159,6 +1172,7 @@ describe('Service: searchSvc: Solr', function () {
 
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -1200,6 +1214,7 @@ describe('Service: searchSvc: Solr', function () {
 
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -1220,7 +1235,7 @@ describe('Service: searchSvc: Solr', function () {
 
     beforeEach(function() {
       fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
     });
 
@@ -1273,7 +1288,7 @@ describe('Service: searchSvc: Solr', function () {
 
     beforeEach(function() {
       fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
-      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
+      searcher = searchSvc.createSearcher(fieldSpec.fieldList(), fieldSpec.highlightFieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
     });
 
@@ -1313,6 +1328,7 @@ describe('Service: searchSvc: Solr', function () {
 
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText,
@@ -1456,6 +1472,7 @@ describe('Service: searchSvc: Solr', function () {
     it('passes two solr queries one explains the other', function() {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -1485,6 +1502,7 @@ describe('Service: searchSvc: Solr', function () {
     it('highlights explain other', function() {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText
@@ -1517,6 +1535,7 @@ describe('Service: searchSvc: Solr', function () {
     it('does not throw an error if both queries are empty', function () {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         ''
@@ -1537,6 +1556,7 @@ describe('Service: searchSvc: Solr', function () {
     it('paginates for explain other seraches', function() {
       var searcher = searchSvc.createSearcher(
         mockFieldSpec.fieldList(),
+        mockFieldSpec.highlightFieldList(),
         mockSolrUrl,
         mockSolrParams,
         mockQueryText


### PR DESCRIPTION
Highlighting over all fields as the default choice continues to generate issues in various places.  We've mucked around with changing highlighters, like for Solr using the `unified` one, which fixes some issues, but we still have other issues, like attempting to highlight a function!

I'm taking a stab at seperating out the highlightable fields from regular fields, which in the future might open the door to having people set their own highlightable fields list.