### PR TITLE
Use the right escape value when creating the pagination searcher

### DIFF
--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -86,6 +86,7 @@
       nextArgs.start      = ['' + start];
       var pageConfig      = defaultSolrConfig;
       pageConfig.sanitize = false;
+      pageConfig.escapeQuery = self.config.escapeQuery;
 
       var options = {
         fieldList:          self.fieldList,

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -703,7 +703,10 @@ describe('Service: searchSvc: Solr', function () {
         mockFieldSpec.fieldList(),
         mockSolrUrl,
         mockSolrParams,
-        queryWithSpecialChars
+        queryWithSpecialChars,
+        {
+          escapeQuery: true,
+        }
       );
 
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, thisExpectedParams))
@@ -1275,6 +1278,22 @@ describe('Service: searchSvc: Solr', function () {
       fieldSpec = fieldSpecSvc.createFieldSpec('id:path content');
       searcher = searchSvc.createSearcher(fieldSpec.fieldList(), mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
+    });
+
+    it("does not escapes the query if escapeQuery is false", function () {
+      var searcher = searchSvc.createSearcher(
+        mockFieldSpec.fieldList(),
+        mockSolrUrl,
+        mockSolrParams,
+        mockQueryText,
+        {
+          escapeQuery: false,
+        }
+      );
+
+      // get page 2
+      var nextSearcher = searcher.pager();
+      expect(nextSearcher.config.escapeQuery).toBeFalse();
     });
 
     it('pages on page', function() {


### PR DESCRIPTION
When calling `searcher.pager()` for the Solr service the newly returned searcher was _always_ using `defaultSolrConfig` as config options, ignoring the `escapeQuery` option.

Most of the time this is not an issue because queries are escaped by default. I hit this issue while using quepid with a query like `field:(term)`, and the second batch of results would use the escaped query: `field\:\(term\)`.

This causes that while the first page loads the desired results. If we navigate to the second page a _potentially_ different result set would be returned.