### PR TITLE
Add support for scripted fields

### DIFF
--- a/factories/docFactory.js
+++ b/factories/docFactory.js
@@ -8,55 +8,65 @@
 
   function DocFactory() {
     var Doc = function(doc, opts) {
-      var self        = this;
-
+      var self = this;
       angular.copy(doc, self);
-
-      self.doc             = doc;
-
-      self.groupedBy       = groupedBy;
-      self.group           = group;
-      self.options         = options;
-      self.version         = version;
-      self.fieldsAttrName  = fieldsAttrName;
-      self.fieldsProperty  = fieldsProperty;
-
-      function groupedBy () {
-        if (opts.groupedBy === undefined) {
-          return null;
-        } else {
-          return opts.groupedBy;
-        }
-      }
-
-      function options() {
-        return opts;
-      }
-
-      function group () {
-        if (opts.group === undefined) {
-          return null;
-        } else {
-          return opts.group;
-        }
-      }
-
-      function version () {
-        if (opts.version === undefined) {
-          return null;
-        } else {
-          return opts.version;
-        }
-      }
-
-      function fieldsAttrName() {
-        return '_source';
-      }
-
-      function fieldsProperty() {
-        return self[self.fieldsAttrName()];
-      }
+      self.doc = doc;
+      self.opts = opts;
     };
+
+    Doc.prototype = {};
+    Doc.prototype.groupedBy = groupedBy;
+    Doc.prototype.group = group;
+    Doc.prototype.options = options;
+    Doc.prototype.version = version;
+    Doc.prototype.fieldsAttrName = fieldsAttrName;
+    Doc.prototype.fieldsProperty = fieldsProperty;
+
+    function groupedBy() {
+      /*jslint validthis:true*/
+      var self = this;
+      if (this.opts.groupedBy === undefined) {
+        return null;
+      } else {
+        return this.opts.groupedBy;
+      }
+    }
+
+    function options() {
+      /*jslint validthis:true*/
+      var self = this;
+      return this.opts;
+    }
+
+    function group() {
+      /*jslint validthis:true*/
+      var self = this;
+      if (this.opts.group === undefined) {
+        return null;
+      } else {
+        return this.opts.group;
+      }
+    }
+
+    function version() {
+      /*jslint validthis:true*/
+      var self = this;
+      if (this.opts.version === undefined) {
+        return null;
+      } else {
+        return this.opts.version;
+      }
+    }
+
+    function fieldsAttrName() {
+      return '_source';
+    }
+
+    function fieldsProperty() {
+      /*jslint validthis:true*/
+      var self = this;
+      return self[self.fieldsAttrName()];
+    }
 
     // Return factory object
     return Doc;

--- a/factories/esDocFactory.js
+++ b/factories/esDocFactory.js
@@ -33,11 +33,12 @@
     Doc.prototype = Object.create(DocFactory.prototype);
     Doc.prototype.constructor = Doc; // Reset the constructor
 
-    Doc.prototype._url       = _url;
-    Doc.prototype.explain    = explain;
-    Doc.prototype.snippet    = snippet;
-    Doc.prototype.origin     = origin;
-    Doc.prototype.highlight  = highlight;
+    Doc.prototype._url           = _url;
+    Doc.prototype.fieldsProperty = fieldsProperty;
+    Doc.prototype.explain        = explain;
+    Doc.prototype.snippet        = snippet;
+    Doc.prototype.origin         = origin;
+    Doc.prototype.highlight      = highlight;
 
     function _url () {
       /*jslint validthis:true*/
@@ -47,6 +48,12 @@
 
       var uri = esUrlSvc.parseUrl(esurl);
       return esUrlSvc.buildDocUrl(uri, doc);
+    }
+
+    function fieldsProperty() {
+      /*jslint validthis:true*/
+      var self = this;
+      return Object.assign({}, self['_source'], self['fields']);
     }
 
     function explain () {

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -101,10 +101,6 @@ angular.module('o19s.splainer-search')
         }
       };
 
-      var setFieldsParamName = function() {
-        self.fieldsParamNames = [ '_source'];
-      };
-
       function prepare (searcher) {
         if (searcher.config === undefined) {
           searcher.config = defaultESConfig;
@@ -113,8 +109,6 @@ angular.module('o19s.splainer-search')
           // the default config object.
           searcher.config = angular.merge({}, defaultESConfig, searcher.config);
         }
-
-        setFieldsParamName(searcher);
 
         if ( searcher.config.apiMethod === 'post') {
           preparePostRequest(searcher);


### PR DESCRIPTION
This change enables [scripted fields](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/search-fields.html#script-fields) to be queried when examining ElasticSearch results. It does so by merging the `_source` result property with the `fields` result property for ElasticSearch documents.

I'm not totally thrilled with the implementation, because the `fieldsAttrName` method isn't completely accurate. However, at least within splainer, this method isn't even used outside of the `fieldsProperty` method. I'm open to feedback about the implementation choice, potentially even removing `fieldsAttrName` if this is bothersome.