### PR TITLE
fix: fix fetching docs for snapshots via Elastic

### DIFF
--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -153,6 +153,8 @@
       if (esUrlSvc.isTemplateCall(uri)) {
         delete queryDslWithPagerArgs._source;
         delete queryDslWithPagerArgs.highlight;
+      } else if (self.config.highlight===false) {
+        delete queryDslWithPagerArgs.highlight;
       }
 
       self.inError  = false;

--- a/factories/resolverFactory.js
+++ b/factories/resolverFactory.js
@@ -49,12 +49,12 @@
         };
       } else if ( settings.searchEngine === 'es' ) {
         self.args = {
-          'query': {
-            'ids': {
-              'values': ids
-            }
+          query: {
+            terms: {
+              [self.fieldSpec.id]: ids,
+            },
           },
-          size: ids.length
+          size: ids.length,
         };
       }
 


### PR DESCRIPTION
The original issue is explained here:
https://github.com/o19s/quepid/issues/466

This has been tested locally with both id field as `_id` (standard) and an alternative ID field.