### PR TITLE
explainOther fixes

### DIFF
--- a/factories/esSearcherFactory.js
+++ b/factories/esSearcherFactory.js
@@ -286,7 +286,7 @@
         args:       self.args,
         queryText:  otherQuery,
         config:     {
-          apiMethod:    'post',
+          apiMethod:    'POST',
           numberOfRows: self.config.numberOfRows,
           version:      self.config.version,
         },

--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -43,6 +43,13 @@ angular.module('o19s.splainer-search')
             var hl = { fields: {} };
 
             angular.forEach(fields, function(fieldName) {
+              /*
+               * ES doesn't like highlighting on _id if the query has been filtered on _id using a terms query.
+               */
+              if (fieldName === '_id') {
+                return;
+              }
+
               hl.fields[fieldName] = { };
             });
 

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -841,7 +841,6 @@ describe('Service: searchSvc: ElasticSearch', function() {
         var esQuery           = angular.fromJson(data);
         var expectedHighlight = {
           fields: {
-            _id:    { },
             title:  { },
           }
         };
@@ -872,7 +871,6 @@ describe('Service: searchSvc: ElasticSearch', function() {
         var esQuery           = angular.fromJson(data);
         var expectedHighlight = {
           fields: {
-            _id:      { },
             title:    { },
             section:  { },
             tags:     { },


### PR DESCRIPTION
A couple issues were breaking "Show Only Rated" in quepid.  Highlighting on `_id` after a terms match in ES causes a index out of bounds exception.  Also, the API method in explainOther needed to have the right case, might make a constants file at some point.

No changes required to Quepid other than cutting a new splainer release and bumping it.