### PR TITLE
OMG, turns out the explain API url has changed in OS and ES7+, and we…

### DIFF
--- a/services/esUrlSvc.js
+++ b/services/esUrlSvc.js
@@ -80,7 +80,7 @@ angular.module('o19s.splainer-search')
         var url = self.buildBaseUrl(uri);
 
         url = url + '/' + index + '/';
-        if (type) {
+        if (!addExplain && type) {
           url = url + type + '/';
         }
 

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -1105,7 +1105,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.expectPOST(url).respond(200, expectedResponse);
 
       angular.forEach(expectedDocs, function(doc) {
-        var explainUrl = "http://localhost:9200/statedecoded/law/";
+        var explainUrl = "http://localhost:9200/statedecoded/";
         explainUrl += '_explain/' + doc._id;
         $httpBackend.expectPOST(explainUrl).respond(200, expectedExplainResponse);
       });
@@ -1123,7 +1123,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.expectPOST(url).respond(200, expectedResponse);
 
       angular.forEach(expectedDocs, function(doc) {
-        var explainUrl = "http://localhost:9200/statedecoded/law/";
+        var explainUrl = "http://localhost:9200/statedecoded/";
         explainUrl += '_explain/' + doc._id;
         $httpBackend.expectPOST(explainUrl).respond(200, expectedExplainResponse);
       });
@@ -1145,7 +1145,7 @@ describe('Service: searchSvc: ElasticSearch', function() {
       $httpBackend.expectPOST(url).respond(200, expectedResponse);
 
       angular.forEach(expectedDocs, function(doc) {
-        var explainUrl = "http://localhost:9200/statedecoded/law/";
+        var explainUrl = "http://localhost:9200/statedecoded/";
         explainUrl += '_explain/' + doc._id;
         $httpBackend.expectPOST(explainUrl).respond(200, expectedExplainResponse);
       });

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -186,7 +186,7 @@ describe('Service: esUrlSvc', function () {
     it('builds a proper doc explain URL from the doc info', function() {
       var docUrl = esUrlSvc.buildExplainUrl(uri, doc);
 
-      expect(docUrl).toBe('http://localhost:9200/tmdb/movies/_explain/1');
+      expect(docUrl).toBe('http://localhost:9200/tmdb/_explain/1');
     });
   });
 


### PR DESCRIPTION
… have the old urls...