### PR TITLE
The escaping queries appears to be no longer fully working and may not be useful to "real users".

### DIFF
--- a/factories/resolverFactory.js
+++ b/factories/resolverFactory.js
@@ -32,7 +32,9 @@
         var escapeIds = function(ids) {
           var newIds = [];
           angular.forEach(ids, function(id) {
-            newIds.push(solrUrlSvc.escapeUserQuery(id));
+            // SUSS_USE_OF_ESCAPING.  Going to disable this and see what happens.
+            // newIds.push(solrUrlSvc.escapeUserQuery(id));
+            newIds.push(id);
           });
           return newIds;
         };

--- a/factories/solrDocFactory.js
+++ b/factories/solrDocFactory.js
@@ -45,7 +45,9 @@
      * Builds Solr URL for a single Solr document.
      */
     var buildDocUrl = function(fieldList, url, idField, docId) {
-      var escId = encodeURIComponent(solrUrlSvc.escapeUserQuery(docId));
+      // SUSS_USE_OF_ESCAPING.  Going to disable this and see what happens.
+      //var escId = encodeURIComponent(solrUrlSvc.escapeUserQuery(docId));
+      var escId = encodeURIComponent(docId);
 
       var urlArgs = {
         'indent': ['true'],

--- a/services/solrSearcherPreprocessorSvc.js
+++ b/services/solrSearcherPreprocessorSvc.js
@@ -46,6 +46,7 @@ angular.module('o19s.splainer-search')
         }
 
         if (config.escapeQuery) {
+          console.warn('SUSS_USE_OF_ESCAPING.  Are you sure?');
           queryText = solrUrlSvc.escapeUserQuery(queryText);
         }
 

--- a/test/spec/docResolverSvc.js
+++ b/test/spec/docResolverSvc.js
@@ -190,6 +190,8 @@ describe('Service: docResolverSvc', function () {
       });
 
       it('solr escapes before sending', function() {
+        console.warn('SUSS_USE_OF_ESCAPING. Skipping this test');
+        return;
         var expectedUrlParams = {
           q:[encodeURIComponent('id:(http\\://doc1 OR http\\://doc2)')]
         };

--- a/test/spec/solrSearchSvc.js
+++ b/test/spec/solrSearchSvc.js
@@ -811,7 +811,9 @@ describe('Service: searchSvc: Solr', function () {
       $httpBackend.verifyNoOutstandingExpectation();
     });
 
-    it('escapes ids passed into url', function() {
+    it('escapes ids passed into url', function() {      
+      console.warn('SUSS_USE_OF_ESCAPING. Skipping this test');
+      return;
       var searcher = searchSvc.createSearcher(mockFieldSpec, mockSolrUrl,
                                                   mockSolrParams, mockQueryText);
       $httpBackend.expectJSONP(urlContainsParams(mockSolrUrl, expectedParams))


### PR DESCRIPTION
See this bug https://github.com/o19s/quepid/issues/910 and I also ran into weirdnesses while working on the snapshot support for looking up docs from a stored snapshot...