### PR TITLE
add checking of template queries and GET

### DIFF
--- a/services/esSearcherPreprocessorSvc.js
+++ b/services/esSearcherPreprocessorSvc.js
@@ -3,8 +3,9 @@
 angular.module('o19s.splainer-search')
   .service('esSearcherPreprocessorSvc', [
     'queryTemplateSvc',
+    'esUrlSvc',
     'defaultESConfig',
-    function esSearcherPreprocessorSvc(queryTemplateSvc, defaultESConfig) {
+    function esSearcherPreprocessorSvc(queryTemplateSvc, esUrlSvc, defaultESConfig) {
       var self = this;
 
       // Attributes
@@ -90,6 +91,9 @@ angular.module('o19s.splainer-search')
       };
 
       var prepareGetRequest = function (searcher) {
+        if (esUrlSvc.isTemplateCall(searcher.args)) {
+          throw new Error('Template queries must be executed via POST, not GET.');
+        }
         searcher.url = searcher.url + '?q=' + searcher.queryText;
 
         var pagerArgs = angular.copy(searcher.args.pager);

--- a/test/spec/esSearchSvc.js
+++ b/test/spec/esSearchSvc.js
@@ -1332,6 +1332,36 @@ describe('Service: searchSvc: ElasticSearch', function() {
       expect(called).toEqual(1);
     });
   });
+  
+  describe('errors on GET versus POST', function() {
+    beforeEach(inject(function () {
+
+    }));
+
+    it('throws an Error on a GET', function() {
+      // the 'id' tells us that we have a templated search.
+      var mockEsParams  = {
+        id: 'tmdb-title-search-template',
+        params: {
+          search_query: 'star'
+        }
+      };
+      
+      var config = {
+        apiMethod: 'GET'
+      }
+   
+      expect(() => {searchSvc.createSearcher(
+        mockFieldSpec,
+        mockEsUrl,
+        mockEsParams,
+        mockQueryText,
+        config,
+        'es'
+      );
+      }).toThrowError('Template queries must be executed via POST, not GET.');      
+    });
+  });
   describe('scripted fields', function() {
     var mockScriptedResults = {
       hits: {


### PR DESCRIPTION
Today at least, we only support a POST with a body of args, if you do GET we squeeze parameters on after the ?, which doesn't work for tempaltes.