### PR TITLE
Smarter handling of Basic Auth and encoded characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Version numbers correspond to `package.json` version.  Follows the _major.minor.bugfix_ naming pattern as of 2.8.0.
 
+# 2.33.0 (2025-02-28)
+- Smarter handling of basic auth, especially when you have special characters like $ and @ in the password.  
+For all api methods except JSONP, we use the Authorization header, even if you pass in a url with the embedded basic auth like http://user:pass@myserver.com.  
+Then for JSONP, which does NOT support headers, we embed the basic auth back into the URL.  
+FYI: Chrome does NOT allow you to use embedded username password in the URL.
+Thanks @atarora for opening https://github.com/o19s/quepid/issues/1245 and @david-fisher for isolating the root causes.
+
 # 2.32.0 (2024-02-07)
 - Algolia support added!   Thanks @sumitsarker for the great contribution, https://github.com/o19s/splainer-search/pull/145.
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ Splainer-search is written using AngularJS project. It requires `npm` and `grunt
 * On Ubuntu [follow these instructions](https://rtcamp.com/tutorials/nodejs/node-js-npm-install-ubuntu/)
 * Use npm to install Grunt globally on your system (may require sudo)
 
+Make sure you have a recent Node.js version installed, older versions won't work.  Version 20 or newer.
+
 ```
 npm install -g grunt-cli
 ```

--- a/factories/httpJsonpTransportFactory.js
+++ b/factories/httpJsonpTransportFactory.js
@@ -20,7 +20,20 @@
 
     Transport.prototype.query = query;
 
-    function query(url) {
+    function query(url, payload, headers) {
+      
+      // JSONP doesn't support headers, so we need to encode the user password in the URL. 
+      // Special characters need to be encoded. 
+      if (headers && headers['Authorization']) {
+        let userPassword = headers['Authorization'];
+        userPassword = userPassword.replace('Basic ', '');
+        userPassword = atob(userPassword);
+        userPassword = userPassword.split(':');
+        userPassword = userPassword[0] + ':' + encodeURIComponent(userPassword[1]);
+
+        url = url.replace('://', '://' + userPassword + '@');
+      }
+      
       url = $sce.trustAsResourceUrl(url);
       
       // you don't get header or payload support with jsonp, it's akin to GET requests that way.

--- a/factories/solrSearcherFactory.js
+++ b/factories/solrSearcherFactory.js
@@ -235,20 +235,14 @@
         if (self.config && self.config.apiMethod) {
           apiMethod = self.config.apiMethod;
         }
+
+        let uri = esUrlSvc.parseUrl(url);          
+        var headers   = esUrlSvc.getHeaders(uri, self.config.customHeaders);  
+        url = esUrlSvc.stripBasicAuth(url);
         
-        var headers   = null;
         var proxyUrl  = self.config.proxyUrl;
         
-        var transport = transportSvc.getTransport({apiMethod: apiMethod, proxyUrl: proxyUrl});
-        
-        if (apiMethod === 'JSONP'){
-          // JSONP is weird.  You don't get headers, and you must embed basic auth IN the url
-        }
-        else {
-          let uri = esUrlSvc.parseUrl(url);
-          url     = esUrlSvc.buildUrl(uri);          
-          headers = esUrlSvc.getHeaders(uri, self.config.customHeaders);                  
-        }
+        var transport = transportSvc.getTransport({apiMethod: apiMethod, proxyUrl: proxyUrl});        
 
         transport.query(url, null, headers)
           .then(function success(resp) {

--- a/services/esUrlSvc.js
+++ b/services/esUrlSvc.js
@@ -23,6 +23,7 @@ angular.module('o19s.splainer-search')
       self.buildRenderTemplateUrl = buildRenderTemplateUrl;
       self.setParams        = setParams;
       self.getHeaders       = getHeaders;
+      self.stripBasicAuth   = stripBasicAuth;
       self.isBulkCall       = isBulkCall;
       self.isTemplateCall   = isTemplateCall;
 
@@ -196,6 +197,15 @@ angular.module('o19s.splainer-search')
         }
 
         return headers;
+      }
+      
+      /**
+       *
+       * Removes any embedded user:password@ from a URL.
+       *
+       */
+      function stripBasicAuth(url) {
+          return url.replace(/(:\/\/)([^@]+)@/, '$1');
       }
 
       function isBulkCall (uri) {

--- a/services/searchSvc.js
+++ b/services/searchSvc.js
@@ -48,14 +48,23 @@ angular.module('o19s.splainer-search')
           type:           searchEngine
         };
 
-        // if we have options.config.basicAuthCredential, then inject it into the URL
-        // and let that go forward.
         if (options.config && options.config.basicAuthCredential && options.config.basicAuthCredential.length > 0) {
-          options.url = this.addBasicAuthToUrl(options.url, options.config.basicAuthCredential);
+          // set up basic auth as a header
+          var encoded = btoa(options.config.basicAuthCredential);
+          if (options.config.customHeaders && options.config.customHeaders.length > 0) {
+            // already something there, append a new entry
+            let head = JSON.parse(options.config.customHeaders);
+            head['Authorization'] = 'Basic ' + encoded;
+            options.config.customHeaders = JSON.stringify(head);
+          } else {
+              // empty, so insert
+            let head = { 'Authorization': 'Basic ' + encoded };
+            options.config.customHeaders = JSON.stringify(head);
+          }
         }
-
+        
         var searcher;
-
+        
         if ( searchEngine === 'solr') {
           options.HIGHLIGHTING_PRE  = svc.HIGHLIGHTING_PRE;
           options.HIGHLIGHTING_POST = svc.HIGHLIGHTING_POST;
@@ -80,9 +89,5 @@ angular.module('o19s.splainer-search')
         return activeQueries.count;
       };
 
-      this.addBasicAuthToUrl = function (url, basicAuthCredential) {
-        var authUrl = url.replace('://', '://' + basicAuthCredential + '@');
-        return authUrl;
-      };
     }
   ]);

--- a/test/spec/esUrlSvc.js
+++ b/test/spec/esUrlSvc.js
@@ -234,4 +234,22 @@ describe('Service: esUrlSvc', function () {
       expect(returnedUrl).toBe(url + '?foo=bar&bar=foo');
     });
   });
+  
+  describe('stripBasicAuth', function() {
+    it('removes embedded basic auth', function() {
+      var url = 'https://user:pass@example.com';
+      
+      var returnedUrl = esUrlSvc.stripBasicAuth(url);
+
+      expect(returnedUrl).toBe('https://example.com');
+    });
+    
+    it('doesnt have issues with no embedded basic auth', function() {
+      var url = 'https://example.com';
+      
+      var returnedUrl = esUrlSvc.stripBasicAuth(url);
+
+      expect(returnedUrl).toBe('https://example.com');
+    });
+  });
 });


### PR DESCRIPTION
Smarter handling of basic auth, especially when you have special characters like $ and @ in the password.  
For all api methods except JSONP, we use the Authorization header, even if you pass in a url with the embedded basic auth like http://user:pass@myserver.com.  
Then for JSONP, which does NOT support headers, we embed the basic auth back into the URL.  
FYI: Chrome does NOT allow you to use embedded username password in the URL.
Thanks @atarora for opening https://github.com/o19s/quepid/issues/1245 and @david-fisher for isolating the root causes.