### PR TITLE
Make sure the Resolver picks up the basic auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Version numbers correspond to `package.json` version.  Follows the _major.minor.bugfix_ naming pattern as of 2.8.0.
 
+# 2.35.0 (2025-07-22)
+- Document Resolver (i.e look up a doc by id) didn't pick up the basic auth credentials, unlike the Searcher.  
+Shows up in Quepid as Snapshot compare failing.  Thanks @kiratraynor for identifying the bug and pairing on the fix.  https://github.com/o19s/splainer-search/pull/153 by @epugh.
+
+
 # 2.34.0 (2025-02-28)
 - Smarter handling of basic auth, especially when you have special characters like $ and @ in the password.  
 For all api methods except JSONP, we use the Authorization header, even if you pass in a url with the embedded basic auth like http://user:pass@myserver.com.  

--- a/factories/resolverFactory.js
+++ b/factories/resolverFactory.js
@@ -79,7 +79,9 @@
         version:      self.settings.version,
         proxyUrl:      self.settings.proxyUrl,
         customHeaders: self.settings.customHeaders,
+        basicAuthCredential: self.settings.basicAuthCredential,
         apiMethod:    self.settings.apiMethod
+         
       };
 
       self.searcher = searchSvc.createSearcher(


### PR DESCRIPTION
Thanks @kiratraynor for finding this bug, and pairing with me to chase it down.  