### PR TITLE
custom search api should respect the number of rows limit

### DIFF
--- a/factories/searchApiSearcherFactory.js
+++ b/factories/searchApiSearcherFactory.js
@@ -124,6 +124,10 @@
               throw new Error('MapperError: ' + errMsg);
             }
           }
+
+          if (self.config.numberOfRows && mappedDocs.length > self.config.numberOfRows) {
+            mappedDocs = mappedDocs.slice(0, self.config.numberOfRows);
+          }
           
           angular.forEach(mappedDocs, function(mappedDoc) {
             const doc = parseDoc(mappedDoc);

--- a/test/spec/searchApiSearchSvc.js
+++ b/test/spec/searchApiSearchSvc.js
@@ -132,5 +132,49 @@ describe('Service: searchSvc: SearchApi', function () {
     $httpBackend.verifyNoOutstandingExpectation();
 
     expect(called).toEqual(1);
-  });  
+  });
+  
+  it('respects numberOfRows configuration', function () {
+    
+    var options = { 
+      apiMethod: 'GET',
+      numberOfRows: 1
+    };
+    options.docsMapper = function(data){    
+      let docs = [];
+      for (let doc of data) {
+        docs.push ({
+          id: doc.id,
+          name: doc.name,
+          title: doc.title,
+        }
+        )
+      }
+      return docs
+    }
+    
+    var searcher = searchSvc.createSearcher(mockFieldSpec, mockSearchApiUrl,
+                                                mockSearchApiParams, mockQueryText, options, 'searchapi');
+    
+    $httpBackend.expectGET("http://example.com:1234/api/search?query=rambo movie").respond(200, mockSearchApiResults);
+
+    var called = 0;
+
+    searcher.search()
+        .then(function () {
+
+          var docs = searcher.docs;
+          expect(docs.length).toEqual(1); // Should only return 1 doc despite mockSearchApiResults having 2
+
+          expect(docs[0].title).toEqual("Rambo");
+          expect(docs[0].id).toEqual(1);
+          
+          called++;
+        });
+    
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+
+    expect(called).toEqual(1);
+  }); 
 });


### PR DESCRIPTION
If you request 5, and the search apir returns 10, well we should retrun 5!